### PR TITLE
fix bug when importing and origin identifier is not known

### DIFF
--- a/src/Salt/SiteBundle/Service/CaseImport.php
+++ b/src/Salt/SiteBundle/Service/CaseImport.php
@@ -104,8 +104,8 @@ class CaseImport
                 if (array_key_exists($cfAssociation->originNodeURI->identifier, $items)) {
                     $lsAssociation->setOrigin($items[$cfAssociation->originNodeURI->identifier]);
                 } else {
-                    $lsAssociation->setOriginNodeUri($cfAssociation->destinationNodeURI->uri);
-                    $lsAssociation->setOriginNodeIdentifier($cfAssociation->destinationNodeURI->identifier);
+                    $lsAssociation->setOriginNodeUri($cfAssociation->originNodeURI->uri);
+                    $lsAssociation->setOriginNodeIdentifier($cfAssociation->originNodeURI->identifier);
                 }
             }
 


### PR DESCRIPTION
The origin gets set to the destination information in one case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/56)
<!-- Reviewable:end -->
