### PR TITLE
generate new UUIDs when importing from ASN [Finishes #145964657]

### DIFF
--- a/app/Resources/assets/js/cftree/view-documentclass.js
+++ b/app/Resources/assets/js/cftree/view-documentclass.js
@@ -1518,6 +1518,18 @@ function apxDocument(initializer) {
         var title;
         if (!empty(a.dest.uri)) {
             title = a.dest.uri;
+
+            if (0 === title.lastIndexOf("data:text/x-", 0)) {
+                // If the destination is a data URI then try to handle it nicer
+                var uri = title.substring(12);
+                var data = uri.split(',', 2);
+
+                if (/;base64[;,]/.test(data[0])) {
+                    title = atob(data[1]);
+                } else {
+                    title = decodeURIComponent(data[1]);
+                }
+            }
         } else if (!empty(a.dest.item)) {
             title = a.dest.item;
         } else if (!empty(a.dest.title)) {
@@ -1529,11 +1541,11 @@ function apxDocument(initializer) {
         var doc = null;
     
         // if the assoc is an exemplar, title is always the uri
-        if (a.type == "exemplar") {
+        if (a.type === "exemplar") {
             title = a.dest.uri;
         
         // else see if the "item" is actually a document
-        } else if (!empty(apx.allDocs[a.dest.item]) && typeof(apx.allDocs[a.dest.item]) != "string") {
+        } else if (!empty(apx.allDocs[a.dest.item]) && typeof(apx.allDocs[a.dest.item]) !== "string") {
             title = "Document: " + apx.allDocs[a.dest.item].doc.title;
         
         // else if we know about this item via allItemsHash...    
@@ -1547,28 +1559,28 @@ function apxDocument(initializer) {
             // so add the association to apx.unknownAssocsShowing; if info about the item is loaded later, it'll get filled in
             apx.unknownAssocsShowing[a.id] = a;
             
-            if (a.dest.doc != "?") {
+            if (a.dest.doc !== "?") {
                 // look for document in allDocs
                 doc = apx.allDocs[a.dest.doc];
         
                 // if we tried to load this document and failed, note that
-                if (doc == "loaderror") {
+                if (doc === "loaderror") {
                     title += " (document could not be loaded)";
 
                 // else if we know we're still in the process of loading that doc, note that
-                } else if (doc == "loading") {
+                } else if (doc === "loading") {
                     title += " (loading document...)";
         
                 // else we have the doc -- this shouldn't normally happen, because if we know about the doc, 
                 // we should have found the item in apx.allItemsHash above
-                } else if (typeof(doc) == "object") {
+                } else if (typeof(doc) === "object") {
                     title += " (item not found in document)";
                 }
             }
         }
 
         // if item comes from another doc, note that
-        if (!empty(doc) && typeof(doc) == "object" && doc != self) {
+        if (!empty(doc) && typeof(doc) === "object" && doc !== self) {
             var docTitle = doc.doc.title;
             if (docTitle.length > 30) {
                 docTitle = docTitle.substr(0, 35);

--- a/src/Cftf/AsnBundle/Command/ImportAsnCommand.php
+++ b/src/Cftf/AsnBundle/Command/ImportAsnCommand.php
@@ -28,8 +28,7 @@ class ImportAsnCommand extends ContainerAwareCommand
         $asnImport = $this->getContainer()->get('cftf_import.asn');
 
         try {
-            $asnDoc = $asnImport->getAsnDocument($asnId);
-            $asnImport->parseAsnDocument($asnDoc, $creator);
+            $asnImport->generateFrameworkFromAsn($asnId);
 
             $output->writeln('Done.');
         } catch (\Exception $e) {

--- a/src/Cftf/AsnBundle/Command/ImportAsnCommand.php
+++ b/src/Cftf/AsnBundle/Command/ImportAsnCommand.php
@@ -28,7 +28,7 @@ class ImportAsnCommand extends ContainerAwareCommand
         $asnImport = $this->getContainer()->get('cftf_import.asn');
 
         try {
-            $asnImport->generateFrameworkFromAsn($asnId);
+            $asnImport->generateFrameworkFromAsn($asnId, $creator);
 
             $output->writeln('Done.');
         } catch (\Exception $e) {

--- a/src/Cftf/AsnBundle/Controller/DefaultController.php
+++ b/src/Cftf/AsnBundle/Controller/DefaultController.php
@@ -25,11 +25,10 @@ class DefaultController extends Controller
         $fileUrl = $request->request->get('fileUrl');
 
         $asnImport = $this->get('cftf_import.asn');
-        $asnDoc = $asnImport->getAsnDocument($fileUrl);
-        $asnImport->parseAsnDocument($asnDoc);
+        $asnImport->generateFrameworkFromAsn($fileUrl);
 
-        return $response->setData(array(
-            'message' => 'Framework imported successfully!'
-        ));
+        return $response->setData([
+            'message' => 'Framework imported successfully!',
+        ]);
     }
 }

--- a/src/Cftf/AsnBundle/Service/AsnImport.php
+++ b/src/Cftf/AsnBundle/Service/AsnImport.php
@@ -5,6 +5,7 @@ namespace Cftf\AsnBundle\Service;
 use Cftf\AsnBundle\Entity\AsnDocument;
 use Cftf\AsnBundle\Entity\AsnStandard;
 use Cftf\AsnBundle\Entity\AsnValue;
+use CftfBundle\Entity\IdentifiableInterface;
 use CftfBundle\Entity\LsAssociation;
 use CftfBundle\Entity\LsDefItemType;
 use CftfBundle\Entity\LsDefSubject;
@@ -58,8 +59,10 @@ class AsnImport
      *
      * @param string $asnDoc
      * @param string|null $creator
+     *
+     * @return LsDoc
      */
-    public function parseAsnDocument($asnDoc, $creator = null)
+    public function parseAsnDocument($asnDoc, $creator = null): LsDoc
     {
         $em = $this->getEntityManager();
 
@@ -68,10 +71,6 @@ class AsnImport
         // Ignoring doc metadata that might be provided
         $sd = $doc->getStandardDocument();
         $lsDoc = new LsDoc();
-
-        $lsDocIdentifier = Uuid::uuid5(Uuid::NAMESPACE_URL, $sd->getIdentifier()->first()->value)->toString();
-        $lsDoc->setIdentifier($lsDocIdentifier);
-        $lsDoc->setUri('local:'.$lsDocIdentifier);
 
         $map = [
             // LsDoc field from AsnStandardDocument field
@@ -97,14 +96,9 @@ class AsnImport
 
                 $s = $em->getRepository('CftfBundle:LsDefSubject')->findOneBy(['title' => $subject]);
                 if (null === $s) {
-                    $uuid = Uuid::uuid5('cacee394-85b7-11e6-9d43-005056a32dda', $subject)->toString();
                     $s = new LsDefSubject();
-                    $s->setIdentifier($uuid);
-                    $s->setUri('local:'.$uuid);
                     $s->setTitle($subject);
                     $s->setHierarchyCode('1');
-
-                    $subjects[$subject] = $s;
 
                     $em->persist($s);
                 }
@@ -121,13 +115,7 @@ class AsnImport
 
         $em->persist($lsDoc);
 
-        $lsAssociation = new LsAssociation();
-        $lsAssociation->setLsDoc($lsDoc);
-        $lsAssociation->setOrigin($lsDoc);
-        $lsAssociation->setType(LsAssociation::EXACT_MATCH_OF);
-        $lsAssociation->setDestinationNodeIdentifier($sd->getIdentifier()->first()->value);
-
-        $em->persist($lsAssociation);
+        $this->addExactMatch($lsDoc, $lsDoc, $sd->getIdentifier()->first());
 
         $seq = 0;
         foreach ($sd->getHasChild() as $val) {
@@ -140,6 +128,8 @@ class AsnImport
         }
 
         $em->flush();
+
+        return $lsDoc;
     }
 
     /**
@@ -152,13 +142,7 @@ class AsnImport
     public function parseAsnStandard(AsnDocument $doc, LsDoc $lsDoc, AsnStandard $asnStandard)
     {
         $em = $this->getEntityManager();
-        $lsItem = new LsItem();
-        $lsItem->setIdentifier(null);
-        $lsItem->setLsDoc($lsDoc);
-
-        $lsItemIdentifier = Uuid::uuid5(Uuid::NAMESPACE_URL, $asnStandard->getIdentifier()->first()->value)->toString();
-        $lsItem->setIdentifier($lsItemIdentifier);
-        $lsItem->setUri('local:'.$lsItemIdentifier);
+        $lsItem = $lsDoc->createItem();
 
         $em->persist($lsItem);
 
@@ -212,13 +196,7 @@ class AsnImport
             $this->addExactMatches($lsDoc, $lsItem, $matches);
         }
 
-        $lsAssociation = new LsAssociation();
-        $lsAssociation->setLsDoc($lsDoc);
-        $lsAssociation->setOrigin($lsItem);
-        $lsAssociation->setType(LsAssociation::EXACT_MATCH_OF);
-        $lsAssociation->setDestinationNodeIdentifier($asnStandard->getIdentifier()->first()->value);
-
-        $em->persist($lsAssociation);
+        $this->addExactMatch($lsDoc, $lsItem, $asnStandard->getIdentifier()->first());
 
         $seq = 0;
         if ($children = $asnStandard->getHasChild()) {
@@ -236,16 +214,28 @@ class AsnImport
     /**
      * @param string $asnLocator
      *
+     * @return LsDoc
+     */
+    public function generateFrameworkFromAsn(string $asnLocator): LsDoc
+    {
+        $asnDoc = $this->fetchAsnDocument($asnLocator);
+
+        return $this->parseAsnDocument($asnDoc);
+    }
+
+    /**
+     * @param string $asnLocator
+     *
      * @return string
      *
      * @throws \Exception
      */
-    public function getAsnDocument(string $asnLocator)
+    public function fetchAsnDocument(string $asnLocator)
     {
         $asnId = '';
         $asnHost = '';
 
-        if (preg_match('/(D\d+)/', $asnLocator, $matches)) {
+        if (preg_match('/(D[\dA-F]+)/', $asnLocator, $matches)) {
             $asnId = $matches[1];
         }
 
@@ -363,22 +353,57 @@ class AsnImport
 
     /**
      * @param LsDoc $lsDoc
-     * @param LsItem $lsItem
+     * @param IdentifiableInterface $origin
      * @param AsnValue[] $matches
      */
-    protected function addExactMatches(LsDoc $lsDoc, LsItem $lsItem, $matches)
+    protected function addExactMatches(LsDoc $lsDoc, IdentifiableInterface $origin, $matches)
     {
         foreach ($matches as $match) {
-            $assoc = new LsAssociation();
-            $assoc->setLsDoc($lsDoc);
-            $assoc->setType(LsAssociation::EXACT_MATCH_OF);
-            $assoc->setOriginLsItem($lsItem);
-            $assoc->setDestinationNodeUri($match->value);
-            $assoc->setDestinationNodeIdentifier($match->value);
-
-            $lsItem->addAssociation($assoc);
-
-            $this->em->persist($assoc);
+            $this->addExactMatch($lsDoc, $origin, $match);
         }
+    }
+
+    /**
+     * @param LsDoc $lsDoc
+     * @param IdentifiableInterface $origin
+     * @param mixed $match
+     *
+     * @return LsAssociation
+     */
+    protected function addExactMatch(LsDoc $lsDoc, IdentifiableInterface $origin, $match): LsAssociation
+    {
+        $assoc = $lsDoc->createAssociation();
+        $assoc->setType(LsAssociation::EXACT_MATCH_OF);
+        $assoc->setOrigin($origin);
+        if ($origin instanceof LsItem) {
+            $origin->addAssociation($assoc);
+        }
+
+        $value = $match->value;
+        if (Uuid::isValid($value)) {
+            $uriType = ';type=uuid';
+            $identifier = $value;
+        } elseif (false !== filter_var($value, FILTER_VALIDATE_URL)) {
+            $uriType = ';type=url';
+            $identifier = Uuid::uuid5(Uuid::NAMESPACE_URL, $value)->toString();
+        } elseif (false !== preg_match('/^urn:guid:/', $value)) {
+            // ASN uses "urn:guid:<uuid>" which is not really valid
+            // Turn the value into a UUID for the identifier and mark as a guid
+            $value = preg_replace('/^urn:guid:/', '', $value);
+            $uriType = ';type=guid';
+            $identifier = Uuid::fromString($value)->toString();
+        } else {
+            $uriType = '';
+            $nsId = 'cd9d92fe-20fd-552f-9ee2-6df3f98a62de'; // Uuid::uuid5(NIL, 'data:text/x-ref;src=ASN')
+            $identifier = Uuid::uuid5($nsId, $value)->toString();
+        }
+        $assoc->setDestination(
+            "data:text/x-ref;src=ASN{$uriType},".rawurlencode($value),
+            $identifier
+        );
+
+        $this->em->persist($assoc);
+
+        return $assoc;
     }
 }

--- a/src/Cftf/AsnBundle/Service/AsnImport.php
+++ b/src/Cftf/AsnBundle/Service/AsnImport.php
@@ -62,7 +62,7 @@ class AsnImport
      *
      * @return LsDoc
      */
-    public function parseAsnDocument($asnDoc, $creator = null): LsDoc
+    public function parseAsnDocument(string $asnDoc, ?string $creator = null): LsDoc
     {
         $em = $this->getEntityManager();
 
@@ -213,14 +213,15 @@ class AsnImport
 
     /**
      * @param string $asnLocator
+     * @param string|null $creator
      *
      * @return LsDoc
      */
-    public function generateFrameworkFromAsn(string $asnLocator): LsDoc
+    public function generateFrameworkFromAsn(string $asnLocator, ?string $creator = null): LsDoc
     {
         $asnDoc = $this->fetchAsnDocument($asnLocator);
 
-        return $this->parseAsnDocument($asnDoc);
+        return $this->parseAsnDocument($asnDoc, $creator);
     }
 
     /**

--- a/src/CftfBundle/Controller/DocTreeController.php
+++ b/src/CftfBundle/Controller/DocTreeController.php
@@ -635,6 +635,7 @@ class DocTreeController extends Controller
             // if document not found, error
             return new Response('Document not found.', Response::HTTP_NOT_FOUND);
         }
+
         return $this->exportAction($newDoc);
     }
 

--- a/src/CftfBundle/Entity/IdentifiableInterface.php
+++ b/src/CftfBundle/Entity/IdentifiableInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace CftfBundle\Entity;
+
+/**
+ * Interface IdentifiableInterface
+ */
+interface IdentifiableInterface
+{
+    /**
+     * @return null|string
+     */
+    public function getIdentifier(): ?string;
+
+    /**
+     * @return null|string
+     */
+    public function getUri(): ?string;
+}

--- a/src/CftfBundle/Entity/LsAssociation.php
+++ b/src/CftfBundle/Entity/LsAssociation.php
@@ -5,6 +5,7 @@ namespace CftfBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation as Serializer;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -305,10 +306,20 @@ class LsAssociation implements CaseApiInterface
 
     /**
      * Constructor
+     *
+     * @param string|Uuid|null $identifier
      */
-    public function __construct()
+    public function __construct($identifier = null)
     {
-        $this->identifier = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        if ($identifier instanceof Uuid) {
+            $identifier = strtolower($identifier->toString());
+        } elseif (is_string($identifier) && Uuid::isValid($identifier)) {
+            $identifier = strtolower(Uuid::fromString($identifier)->toString());
+        } else {
+            $identifier = Uuid::uuid1()->toString();
+        }
+
+        $this->identifier = $identifier;
         $this->uri = 'local:'.$this->identifier;
         $this->updatedAt = new \DateTime();
     }
@@ -446,24 +457,25 @@ class LsAssociation implements CaseApiInterface
      * Set the Origination of the association
      *
      * @param string|LsDoc|LsItem $origin
+     * @param string|null $identifier
      *
      * @return LsAssociation
      *
      * @throws \UnexpectedValueException
      */
-    public function setOrigin($origin): LsAssociation
+    public function setOrigin($origin, ?string $identifier = null): LsAssociation
     {
         if (is_string($origin)) {
             $this->setOriginNodeUri($origin);
-            $this->setOriginNodeIdentifier($origin);
-        } elseif ($origin instanceof LsDoc) {
-            $this->setOriginLsDoc($origin);
+            $this->setOriginNodeIdentifier($identifier ?? $origin);
+        } elseif ($origin instanceof IdentifiableInterface) {
+            if ($origin instanceof LsDoc) {
+                $this->setOriginLsDoc($origin);
+            } elseif ($origin instanceof LsItem) {
+                $this->setOriginLsItem($origin);
+            }
             $this->setOriginNodeUri($origin->getUri());
-            $this->setOriginNodeIdentifier($origin->getIdentifier());
-        } elseif ($origin instanceof LsItem) {
-            $this->setOriginLsItem($origin);
-            $this->setOriginNodeUri($origin->getUri());
-            $this->setOriginNodeIdentifier($origin->getIdentifier());
+            $this->setOriginNodeIdentifier($identifier ?? $origin->getIdentifier());
         } else {
             throw new \UnexpectedValueException('The value must be a URI, an LsDoc, or an LsItem');
         }
@@ -480,9 +492,13 @@ class LsAssociation implements CaseApiInterface
     {
         if ($this->getOriginLsDoc()) {
             return $this->getOriginLsDoc();
-        } elseif ($this->getOriginLsItem()) {
+        }
+
+        if ($this->getOriginLsItem()) {
             return $this->getOriginLsItem();
-        } elseif ($this->getOriginNodeUri()) {
+        }
+
+        if ($this->getOriginNodeUri()) {
             return $this->getOriginNodeUri();
         }
 
@@ -517,24 +533,25 @@ class LsAssociation implements CaseApiInterface
      * Set the Destination of the association
      *
      * @param string|LsDoc|LsItem $destination
+     * @param string|null $identifier
      *
      * @return LsAssociation
      *
      * @throws \UnexpectedValueException
      */
-    public function setDestination($destination): LsAssociation
+    public function setDestination($destination, ?string $identifier = null): LsAssociation
     {
         if (is_string($destination)) {
             $this->setDestinationNodeUri($destination);
-            $this->setDestinationNodeIdentifier($destination);
-        } elseif ($destination instanceof LsDoc) {
-            $this->setDestinationLsDoc($destination);
+            $this->setDestinationNodeIdentifier($identifier ?? $destination);
+        } elseif ($destination instanceof IdentifiableInterface) {
+            if ($destination instanceof LsDoc) {
+                $this->setDestinationLsDoc($destination);
+            } elseif ($destination instanceof LsItem) {
+                $this->setDestinationLsItem($destination);
+            }
             $this->setDestinationNodeUri($destination->getUri());
-            $this->setDestinationNodeIdentifier($destination->getIdentifier());
-        } elseif ($destination instanceof LsItem) {
-            $this->setDestinationLsItem($destination);
-            $this->setDestinationNodeUri($destination->getUri());
-            $this->setDestinationNodeIdentifier($destination->getIdentifier());
+            $this->setDestinationNodeIdentifier($identifier ?? $destination->getIdentifier());
         } else {
             throw new \UnexpectedValueException('The value must be a URI, an LsDoc, or an LsItem');
         }
@@ -551,9 +568,13 @@ class LsAssociation implements CaseApiInterface
     {
         if ($this->getDestinationLsDoc()) {
             return $this->getDestinationLsDoc();
-        } elseif ($this->getDestinationLsItem()) {
+        }
+
+        if ($this->getDestinationLsItem()) {
             return $this->getDestinationLsItem();
-        } elseif ($this->getDestinationNodeUri()) {
+        }
+
+        if ($this->getDestinationNodeUri()) {
             return $this->getDestinationNodeUri();
         }
 
@@ -591,7 +612,39 @@ class LsAssociation implements CaseApiInterface
      */
     public function getHumanCodingSchemeFromDestinationNodeUri()
     {
-        return base64_decode(explode(',', $this->destinationNodeUri)[1]);
+        return $this->splitDestinationDataUri()['value'];
+    }
+
+    /**
+     * Get an array with the information from a data URI
+     *
+     * @return array
+     */
+    public function splitDestinationDataUri()
+    {
+        if (0 !== strncmp($this->destinationNodeUri, 'data:text/x-', 12)) {
+            // Not a known data URI format, return the entire uri as the value
+            return ['value' => $this->destinationNodeUri];
+        }
+
+        $uri = substr($this->destinationNodeUri, 12);
+        [$dataString, $encodedValue] = explode(',', $uri, 2);
+
+        [$textType, $metadataString] = explode(';', $dataString, 2);
+
+        $metadata = ['textType' => $textType];
+        foreach (explode(';', $metadataString) as $param) {
+            [$name, $value] = explode('=', $param, 2);
+            $metadata[$name] = $value ?? true;
+        }
+
+        if ($metadata['base64'] ?? false) {
+            $metadata['value'] = base64_decode($encodedValue);
+        } else {
+            $metadata['value'] = rawurldecode($encodedValue);
+        }
+
+        return $metadata;
     }
 
     /**

--- a/src/CftfBundle/Entity/LsAssociation.php
+++ b/src/CftfBundle/Entity/LsAssociation.php
@@ -456,7 +456,7 @@ class LsAssociation implements CaseApiInterface
     /**
      * Set the Origination of the association
      *
-     * @param string|LsDoc|LsItem $origin
+     * @param string|IdentifiableInterface $origin
      * @param string|null $identifier
      *
      * @return LsAssociation
@@ -532,7 +532,7 @@ class LsAssociation implements CaseApiInterface
     /**
      * Set the Destination of the association
      *
-     * @param string|LsDoc|LsItem $destination
+     * @param string|IdentifiableInterface $destination
      * @param string|null $identifier
      *
      * @return LsAssociation

--- a/src/CftfBundle/Entity/LsDoc.php
+++ b/src/CftfBundle/Entity/LsDoc.php
@@ -60,7 +60,7 @@ use Util\Compare;
  *     }
  * )
  */
-class LsDoc implements CaseApiInterface
+class LsDoc implements CaseApiInterface, IdentifiableInterface
 {
     const ADOPTION_STATUS_PRIVATE_DRAFT = 'Private Draft';
     const ADOPTION_STATUS_DRAFT = 'Draft';
@@ -414,10 +414,20 @@ class LsDoc implements CaseApiInterface
 
     /**
      * Constructor
+     *
+     * @param string|Uuid|null $identifier
      */
-    public function __construct()
+    public function __construct($identifier = null)
     {
-        $this->identifier = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        if ($identifier instanceof Uuid) {
+            $identifier = strtolower($identifier->toString());
+        } elseif (is_string($identifier) && Uuid::isValid($identifier)) {
+            $identifier = strtolower(Uuid::fromString($identifier)->toString());
+        } else {
+            $identifier = Uuid::uuid1()->toString();
+        }
+
+        $this->identifier = $identifier;
         $this->uri = 'local:'.$this->identifier;
         $this->lsItems = new ArrayCollection();
         $this->docAssociations = new ArrayCollection();
@@ -500,7 +510,7 @@ class LsDoc implements CaseApiInterface
      *
      * @return string
      */
-    public function getUri()
+    public function getUri(): ?string
     {
         return $this->uri;
     }
@@ -534,7 +544,7 @@ class LsDoc implements CaseApiInterface
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): ?string
     {
         return $this->identifier;
     }
@@ -1559,5 +1569,31 @@ class LsDoc implements CaseApiInterface
         $this->licence = $licence;
 
         return $this;
+    }
+
+    /**
+     * @param Uuid|string|null $identifier
+     *
+     * @return LsItem
+     */
+    public function createItem($identifier = null): LsItem
+    {
+        $item = new LsItem($identifier);
+        $item->setLsDoc($this);
+
+        return $item;
+    }
+
+    /**
+     * @param Uuid|string|null $identifier
+     *
+     * @return LsAssociation
+     */
+    public function createAssociation($identifier = null): LsAssociation
+    {
+        $association = new LsAssociation($identifier);
+        $association->setLsDoc($this);
+
+        return $association;
     }
 }

--- a/src/CftfBundle/Entity/LsItem.php
+++ b/src/CftfBundle/Entity/LsItem.php
@@ -108,7 +108,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *     }
  * )
  */
-class LsItem implements CaseApiInterface
+class LsItem implements CaseApiInterface, IdentifiableInterface
 {
     /**
      * @var int
@@ -446,19 +446,12 @@ class LsItem implements CaseApiInterface
      */
     public function __construct($identifier = null)
     {
-        if (null !== $identifier) {
-            // If the identifier is in the form of a UUID then lower case it
-            if ($identifier instanceof Uuid) {
-                $identifier = strtolower($identifier->toString());
-            } elseif (is_string($identifier) && Uuid::isValid($identifier)) {
-                $identifier = strtolower(
-                    Uuid::fromString($identifier)->toString()
-                );
-            } else {
-                $identifier = Uuid::uuid4()->toString();
-            }
+        if ($identifier instanceof Uuid) {
+            $identifier = strtolower($identifier->toString());
+        } elseif (is_string($identifier) && Uuid::isValid($identifier)) {
+            $identifier = strtolower(Uuid::fromString($identifier)->toString());
         } else {
-            $identifier = Uuid::uuid4()->toString();
+            $identifier = Uuid::uuid1()->toString();
         }
 
         $this->identifier = $identifier;

--- a/src/CftfBundle/Resources/views/DocTree/_lsAssociationComponent.html.twig
+++ b/src/CftfBundle/Resources/views/DocTree/_lsAssociationComponent.html.twig
@@ -40,10 +40,8 @@
                                     {{ block('end_of_item_a') }}
                                 </a>
                             {% elseif association.destinationNodeUri is not empty %}
-                                {% set uri = association.destinationNodeUri %}
-                                {% if uri starts with 'data:text/x-ref-unresolved' %}
-                                    {% set uri = association.humanCodingSchemeFromDestinationNodeUri %}
-                                {% endif %}
+                                {% set uriData = association.splitDestinationDataUri %}
+                                {% set uri = uriData.value %}
                                 {{ groupLabel|raw }}
                                 <span data-association-id="{{ association.id }}" class="list-group-item lsassociation lsitem-uri clearfix">
                                     {{ uri|local_remote_uri }}


### PR DESCRIPTION
- update js to show the data: uri's better
- add an interface for identifiable (identifer + uri) objects
- generate new UUIDs when importing from ASN [#145964657] so that
  one can create new frameworks based on those from ASN
- add methods to LsDoc to create new items and associations that are
  automatically part of the LsDoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/71)
<!-- Reviewable:end -->
