### PR TITLE
Add locale to the html tag

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -1,12 +1,13 @@
 {%- set authClass = is_granted('ROLE_USER') ? 'auth' : 'no-auth' -%}
 <!DOCTYPE html>
-<html class="no-js {{ authClass }}">
+<html lang="{{ app.request.locale}}" xml:lang="{{ app.request.locale }}" xmlns= "http://www.w3.org/1999/xhtml" class="no-js {{ authClass }}">
     <head>
         <meta charset="utf-8" />
         {% block xuacompatible %}
             <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         {% endblock %}
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta http-equiv="Content-Language" content="{{ app.request.locale }}">
         {% block viewport %}
             <meta name="viewport" content="width=device-width, initial-scale=1">
         {% endblock %}


### PR DESCRIPTION
Under certain (unknown) conditions Google Chrome decides that pages are in a different language and asks if the user wants to translate it.

This PR adds the current locale to the html tag and a meta "Content-Language" tag in order to keep Chrome from thinking it is a different language.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/92)
<!-- Reviewable:end -->
