### PR TITLE
fix loading external frameworks

### DIFF
--- a/src/CftfBundle/Controller/LsDocController.php
+++ b/src/CftfBundle/Controller/LsDocController.php
@@ -346,6 +346,9 @@ class LsDocController extends Controller
      */
     protected function loadDocumentListFromHost(string $hostname): array
     {
+        // Remove any scheme or path from the passed value
+        $hostname = preg_replace('#^(?:https?://)?([^/]+)(?:/.*)#', '$1', $hostname);
+
         try {
             $remoteResponse = $this->loadDocumentsFromServer(
                 'https://'.$hostname

--- a/src/CftfBundle/Resources/views/DocTree/_loadExternalDocumentComponent.html.twig
+++ b/src/CftfBundle/Resources/views/DocTree/_loadExternalDocumentComponent.html.twig
@@ -3,15 +3,15 @@
 
     <div class="form-horizontal">
         <div class="form-group">
-            <label class="col-sm-1 control-label">URL:</label>
+            <label class="col-sm-1 control-label" for="loadExternalDocumentUrl">URL:</label>
             <div class="col-sm-10">
-                <input type="text" class="form-control" id="loadExternalDocumentUrlInput" value="">
+                <input type="text" class="form-control" id="loadExternalDocumentUrlInput" name="loadExternalDocumentUrlInput" value="" />
             </div>
         </div>
     </div>
     
     <p style="margin-top:25px"><b>Example:</b> To load the Common Core ELA standards from PCG’s OpenSALT server, you can use the following url:</p>
     <ul>
-        <li>https://salt-staging.edplancms.com/uri/78123c2e-f5f0-5118-a5bf-6a12355e6fd1.json</li>
+        <li>https://opensalt.net/uri/78123c2e-f5f0-5118-a5bf-6a12355e6fd1.json</li>
     </ul>
 </div>

--- a/src/CftfBundle/Resources/views/DocTree/updateFrameworkModal.html.twig
+++ b/src/CftfBundle/Resources/views/DocTree/updateFrameworkModal.html.twig
@@ -8,7 +8,6 @@
             <div class="modal-body">
                 <ul class="nav nav-tabs" role="tablist">
                     <li class="active"><a href="#local" data-toggle="tab">Update by local file</a></li>
-                    <li class="github-tab"><a href="#loadExternalDocumentTabContent" data-toggle="tab">Load an external document</a></li>
                 </ul>
                 </br>
                 <div class="tab-content">
@@ -19,10 +18,6 @@
                                 <div class="alert alert-danger asn-error-msg hidden" role="alert"></div>
                             </div>
                         </div>
-                    </div>
-                    <div id="loadExternalDocumentTabContent" class="tab-pane">
-                    {% embed 'CftfBundle:DocTree:_loadExternalDocumentComponent.html.twig' with {'view':'editor'} %}
-                    {% endembed %}
                     </div>
                 </div>
             </div>

--- a/src/CftfBundle/Resources/views/LsDoc/remoteIndex.html.twig
+++ b/src/CftfBundle/Resources/views/LsDoc/remoteIndex.html.twig
@@ -19,7 +19,7 @@
                     <li class="folder">{{ framework.creator }}<ul>
                     {% set lastCreator = framework.creator %}
                 {% endif %}
-                <li class="salt-framework-link"><a href="{{ path('doc_tree_remote_view', {'url':framework.CFPackageURI}) |raw }}">{{ framework.title }}</a></li>
+                <li class="salt-framework-link"><a href="{{ path('doc_tree_remote_view', {'url':framework.CFPackageURI.uri}) |raw }}">{{ framework.title }}</a></li>
                 {% if loop.last == true and framework.creator != '' %}
                     </ul></li>
                 {% endif %}


### PR DESCRIPTION
Two input fields had the same id.  Removed the one not being used currently.

[Fixes #150104646]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/95)
<!-- Reviewable:end -->
