### PR TITLE
refactor: deprecate special SYMFONY__ environment vars

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,32 @@
+OpenSALT Configuration
+======================
+
+OpenSALT is intended to be configured using environment variables that can be passed into the docker container.
+
+MySQL configuration
+-------------------
+To set the location of the MySQL database use the environment variables
+
+ - MYSQL_HOST - Hostname to connect to the database
+ - MYSQL_PORT - *(optional)* Port number to use to connect to the database
+ - MYSQL_DATABASE - Name of the database schema
+ - MYSQL_USER - Username used to connect to the database
+ - MYSQL_PASSWORD - Password used to connect to the database
+
+Secrets configuration
+---------------------
+
+A couple secrets are required for creating secure tokens
+
+ - SECRET - Should be a long random string
+ - COOKIE_SECRET - Should be a different long random string
+
+Branding configuration
+----------------------
+
+OpenSALT can have some branding associated with it
+
+ - BRAND_LOGO_URL - URL to the logo shown to the right of the OpenSALT logo
+ - BRAND_LINK_URL - URL that the brand logo will use when clicked
+ - BRAND_LOGO_STYLE - *(optional)* An embedded style that will be added to the **img** tag of the logo
+ - BRAND_LINK_STYLE - *(optional)* An embedded style that will be added ot the **a** tag wrapping the logo

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -26,7 +26,7 @@ Branding configuration
 
 OpenSALT can have some branding associated with it
 
- - BRAND_LOGO_URL - URL to the logo shown to the right of the OpenSALT logo
- - BRAND_LINK_URL - URL that the brand logo will use when clicked
+ - BRAND_LOGO_URL - *(optional)* URL to the logo shown to the right of the OpenSALT logo
+ - BRAND_LINK_URL - *(optional)* URL that the brand logo will use when clicked
  - BRAND_LOGO_STYLE - *(optional)* An embedded style that will be added to the **img** tag of the logo
  - BRAND_LINK_STYLE - *(optional)* An embedded style that will be added ot the **a** tag wrapping the logo

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,6 +17,18 @@ imports:
 # http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en
+    database_host: '%env(MYSQL_HOST)%'
+    database_port: '%env(MYSQL_PORT)%'
+    database_name: '%env(MYSQL_DATABASE)%'
+    database_user: '%env(MYSQL_USER)%'
+    database_password: '%env(MYSQL_PASSWORD)%'
+    mailer_transport: '%env(MAILER_TRANSPORT)%'
+    mailer_host: '%env(MAILER_HOST)%'
+    mailer_user: '%env(MAILER_USER)%'
+    mailer_password: '%env(MAILER_PASSWORD)%'
+    secret: '%env(SECRET)%'
+    cookie_secret: '%env(COOKIE_SECRET)%'
+    local_uri_host: '%env(LOCAL_URI_HOST)%'
     github_client_id: '%env(GITHUB_CLIENT_ID)%'
     github_client_secret: '%env(GITHUB_CLIENT_SECRET)%'
     brand_logo_url: '%env(BRAND_LOGO_URL)%'

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -4,22 +4,29 @@
 parameters:
     locale: en
 
-    database_host: '%mysql.host%'
-    database_port: 3306
-    database_name: '%mysql.database%'
-    database_user: '%mysql.user%'
-    database_password: '%mysql.password%'
+    # The SYMFONY__ environment variables are deprecated
+    env(SYMFONY__MYSQL__HOST): ~
+    env(SYMFONY__MYSQL__DATABASE): ~
+    env(SYMFONY__MYSQL__USER): ~
+    env(SYMFONY__MYSQL__PASSWORD): ~
 
-    mailer_transport:  smtp
-    mailer_host:       127.0.0.1
-    mailer_user:       ~
-    mailer_password:   ~
+    env(MYSQL_HOST): '%env(SYMFONY__MYSQL__HOST)%'
+    env(MYSQL_PORT): 3306
+    env(MYSQL_DATABASE): '%env(SYMFONY__MYSQL__DATABASE)%'
+    env(MYSQL_USER): '%env(SYMFONY__MYSQL__USER)%'
+    env(MYSQL_PASSWORD): '%env(SYMFONY__MYSQL__PASSWORD)%'
+
+    env(MAILER_TRANSPORT): smtp
+    env(MAILER_HOST): 127.0.0.1
+    env(MAILER_USER): ~
+    env(MAILER_PASSWORD): ~
 
     # A secret key that's used to generate certain security-related tokens
-    secret:            ThisTokenIsNotSoSecretSoChangeIt
-    cookie_secret:     ThisTokenIsNotSoSecretChangeIt
+    env(SECRET): ThisTokenIsNotSoSecretSoChangeIt
+    env(COOKIE_SECRET): ThisTokenIsNotSoSecretChangeIt
 
-    local_uri_host: http://localhost:3000/
+    env(LOCAL_URI_HOST): 'http://127.0.0.1:3000/'
+
     env(GITHUB_CLIENT_ID): ~
     env(GITHUB_CLIENT_SECRET): ~
 

--- a/app/config/parameters.yml.no-env
+++ b/app/config/parameters.yml.no-env
@@ -4,22 +4,23 @@
 parameters:
     locale: en
 
-    database_host: 127.0.0.1
-    database_port: 3306
-    database_name: symfony
-    database_user: root
-    database_password: ~
+    env(MYSQL_HOST): '127.0.0.1'
+    env(MYSQL_PORT): 3306
+    env(MYSQL_DATABASE): 'symfony'
+    env(MYSQL_USER): 'root'
+    env(MYSQL_PASSWORD): ~
 
-    mailer_transport:  smtp
-    mailer_host:       127.0.0.1
-    mailer_user:       ~
-    mailer_password:   ~
+    env(MAILER_TRANSPORT): smtp
+    env(MAILER_HOST): 127.0.0.1
+    env(MAILER_USER): ~
+    env(MAILER_PASSWORD): ~
 
     # A secret key that's used to generate certain security-related tokens
-    secret:            ThisTokenIsNotSoSecretSoChangeIt
-    cookie_secret:     ThisTokenIsNotSoSecretChangeIt
+    env(SECRET): ThisTokenIsNotSoSecretSoChangeIt
+    env(COOKIE_SECRET): ThisTokenIsNotSoSecretChangeIt
 
-    local_uri_host: http://localhost:3000/
+    env(LOCAL_URI_HOST): 'http://127.0.0.1:3000/'
+
     env(GITHUB_CLIENT_ID): ~
     env(GITHUB_CLIENT_SECRET): ~
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,10 +8,6 @@ services:
     depends_on:
       - db
     environment:
-      SYMFONY__MYSQL__DATABASE: "${MYSQL_DATABASE}"
-      SYMFONY__MYSQL__USER: "${MYSQL_USER}"
-      SYMFONY__MYSQL__PASSWORD: "${MYSQL_PASSWORD}"
-      SYMFONY__MYSQL__HOST: "${MYSQL_HOST:-db}"
       MYSQL_DATABASE:
       MYSQL_USER:
       MYSQL_PASSWORD:

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -8,10 +8,6 @@ services:
     depends_on:
       - db
     environment:
-      SYMFONY__MYSQL__DATABASE: "${MYSQL_DATABASE}"
-      SYMFONY__MYSQL__USER: "${MYSQL_USER}"
-      SYMFONY__MYSQL__PASSWORD: "${MYSQL_PASSWORD}"
-      SYMFONY__MYSQL__HOST: "${MYSQL_HOST:-db}"
       MYSQL_DATABASE:
       MYSQL_USER:
       MYSQL_PASSWORD:

--- a/docker/docker-compose.tools.yml
+++ b/docker/docker-compose.tools.yml
@@ -8,10 +8,6 @@ services:
     #  context: ./php
     image: opensalt/php:7.1-cli
     environment:
-      SYMFONY__MYSQL__DATABASE: "${MYSQL_DATABASE}"
-      SYMFONY__MYSQL__USER: "${MYSQL_USER}"
-      SYMFONY__MYSQL__PASSWORD: "${MYSQL_PASSWORD}"
-      SYMFONY__MYSQL__HOST: "${MYSQL_HOST:-db}"
       MYSQL_DATABASE:
       MYSQL_USER:
       MYSQL_PASSWORD:
@@ -27,10 +23,6 @@ services:
     #  context: ./composer
     image: opensalt/composer:1.4-7.1
     environment:
-      SYMFONY__MYSQL__DATABASE: "${MYSQL_DATABASE}"
-      SYMFONY__MYSQL__USER: "${MYSQL_USER}"
-      SYMFONY__MYSQL__PASSWORD: "${MYSQL_PASSWORD}"
-      SYMFONY__MYSQL__HOST: "${MYSQL_HOST:-db}"
       MYSQL_DATABASE:
       MYSQL_USER:
       MYSQL_PASSWORD:

--- a/src/Salt/UserBundle/Controller/FrameworkAclController.php
+++ b/src/Salt/UserBundle/Controller/FrameworkAclController.php
@@ -107,6 +107,7 @@ class FrameworkAclController extends Controller
             $dto->lsDoc = $lsDoc;
             $dto->access = UserDocAcl::DENY;
             $command = new AddAclUserCommand();
+
             try {
                 $acl = $command->perform($dto, $em);
                 $em->flush($acl);
@@ -145,6 +146,7 @@ class FrameworkAclController extends Controller
             $dto->lsDoc = $lsDoc;
             $dto->access = UserDocAcl::ALLOW;
             $command = new AddAclUsernameCommand();
+
             try {
                 $acl = $command->perform($dto, $em);
                 $em->flush($acl);

--- a/src/Salt/UserBundle/Controller/OAuthServiceController.php
+++ b/src/Salt/UserBundle/Controller/OAuthServiceController.php
@@ -65,6 +65,7 @@ class OAuthServiceController extends Controller
         // Check given state against previously stored one to mitigate CSRF attack
         } elseif (empty($state) || ($state !== $session->get('oauth2state'))) {
             $session->remove('oauth2state');
+
             throw new \UnexpectedValueException('Invalid state.');
         } else {
             $em = $this->getDoctrine()->getManager();


### PR DESCRIPTION
The special SYMFONY__ environment variables have been deprecated in
Symfony 3.3 (and will be removed in 4.0) as there is now support for
runtime environment variables in Symfony.

This commit allows for different environment variables to be used as the
first step in removing the old variables.  A later step should remove
the `parameters.yml` file entirely and have the configuration be solely
from passed environment variables (or .env file for development).

ref: [Deprecation blog post](https://symfony.com/blog/new-in-symfony-3-3-deprecated-the-special-symfony-environment-variables)
ref: symfony/symfony#21889

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/97)
<!-- Reviewable:end -->
