### PR TITLE
Return a 401 response if the request is from javascript

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -38,6 +38,8 @@ security:
             #stateless: true
             provider: local_db_provider
 
+            entry_point: salt.authentication.json_form_entry_point
+
             # activate different ways to authenticate
 
             # http://symfony.com/doc/current/book/security.html#a-configuring-how-your-users-will-authenticate

--- a/src/Salt/UserBundle/Security/JsonFormAuthenticationEntryPoint.php
+++ b/src/Salt/UserBundle/Security/JsonFormAuthenticationEntryPoint.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Salt\UserBundle\Security;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint;
+
+/**
+ * Class JsonFormAuthenticationEntryPoint
+ *
+ * @DI\Service("salt.authentication.json_form_entry_point", parent="security.authentication.form_entry_point.main")
+ */
+class JsonFormAuthenticationEntryPoint extends FormAuthenticationEntryPoint
+{
+    /**
+     * Returns a response that directs the user to authenticate.
+     *
+     * This is called when an anonymous request accesses a resource that
+     * requires authentication. The job of this method is to return some
+     * response that "helps" the user start into the authentication process.
+     *
+     * @param Request $request The request that resulted in an AuthenticationException
+     * @param AuthenticationException $authException The exception that started the authentication process
+     *
+     * @return Response
+     */
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        if ($request->isXmlHttpRequest() || 'json' === $request->getRequestFormat()) {
+            return new JsonResponse(
+                [
+                    'error' => [
+                        'message' => 'Authentication Required',
+                        'code' => 'AUTH-REQ',
+                    ],
+                ], 401);
+        }
+
+        return parent::start($request, $authException);
+    }
+}


### PR DESCRIPTION
Instead of sending a browser redirect, return a 401 status code when the request requiring authentication is made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/101)
<!-- Reviewable:end -->
