### PR TITLE
Return the correct exit code after running tests

### DIFF
--- a/bin/run-tests
+++ b/bin/run-tests
@@ -7,9 +7,8 @@ RET=$?
 
 ./bin/codecept run
 RET2=$?
-if [ ! "$RET" == "0" ]; then
+if [ "$RET" == "0" ]; then
   RET=$RET2
-  echo "ret2"
 fi
 
 exit $RET


### PR DESCRIPTION
The return of the codeception tests is not returned correctly if the phpspec tests pass.

This PR fixes the return code.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/197)
<!-- Reviewable:end -->
