### PR TITLE
allow for no current ASN frameworks

### DIFF
--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -357,7 +357,11 @@ class Framework implements Context
     {
         $I = $this->I;
 
-        $I->click('//span[text()="Imported from ASN"]/../..');
+        try {
+            $I->click('//span[text()="Imported from ASN"]/../..');
+        } catch (\Exception $e) {
+            // It is okay if there are none
+        }
         $this->importedAsnList = $I->grabMultiple('//span[text()="Imported from ASN"]/../../ul/li/span/span[@class="fancytree-title"]');
 
         return $this;


### PR DESCRIPTION
Fix issue where tests fail when there is no current ASN framework

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/205)
<!-- Reviewable:end -->
