### PR TITLE
switch to chrome over phantomjs for automated tests

### DIFF
--- a/bin/codecept
+++ b/bin/codecept
@@ -2,13 +2,13 @@
 
 cd $(dirname $0)/..
 
-docker-compose -f docker/docker-compose.yml -f docker/docker-compose.browsers.yml up -d phantomjs
+docker-compose -f docker/docker-compose.yml -f docker/docker-compose.browsers.yml up -d chrome
 sleep 2
 
 ./bin/phpcli ./bin/codecept-wrapper "$@"
 RET=$?
 
-docker-compose -f docker/docker-compose.yml -f docker/docker-compose.browsers.yml stop phantomjs
-docker-compose -f docker/docker-compose.yml -f docker/docker-compose.browsers.yml rm -f -v phantomjs
+docker-compose -f docker/docker-compose.yml -f docker/docker-compose.browsers.yml stop chrome
+docker-compose -f docker/docker-compose.yml -f docker/docker-compose.browsers.yml rm -f -v chrome
 
 exit $RET

--- a/docker/docker-compose.browsers.yml
+++ b/docker/docker-compose.browsers.yml
@@ -7,9 +7,15 @@ services:
       - "../tests:/var/www/html/tests"
 
   chrome:
-    image: yukinying/chrome-headless-browser-selenium
-    shm_size: 1024M
-    cap_add:
-      - SYS_ADMIN
+    image: selenium/standalone-chrome:3.5
     volumes:
       - "../tests:/var/www/html/tests"
+
+  firefox:
+    image: selenium/standalone-firefox:3.5
+    volumes:
+      - "../tests:/var/www/html/tests"
+
+  wait:
+    image: jwilder/dockerize
+

--- a/tests/_support/Helper/Guzzle.php
+++ b/tests/_support/Helper/Guzzle.php
@@ -33,7 +33,7 @@ class Guzzle extends \Codeception\Module
 
         $client = new Client([
             'base_uri' => $baseUrl,
-            'timeout' => 10,
+            'timeout' => 30,
         ]);
 
         $headers = [

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -376,8 +376,8 @@ class Framework implements Context
         return $this;
     }
   
-    /*
-     * @Given /^I fill in an ASN document identifier$/
+    /**
+     * @When /^I fill in an ASN document identifier$/
      */
     public function iFillInAnASNDocumentIdentifier(): Framework
     {

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -34,7 +34,6 @@ class Framework implements Context
 
         $I->getLastFrameworkId();
         $I->amOnPage(self::$docPath.$I->getDocId());
-        $I->waitForElementVisible('#modalSpinner');
         $I->waitForElementNotVisible('#modalSpinner');
 
         return $this;

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -34,6 +34,8 @@ class Framework implements Context
 
         $I->getLastFrameworkId();
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementVisible('#modalSpinner');
+        $I->waitForElementNotVisible('#modalSpinner');
 
         return $this;
     }

--- a/tests/_support/Page/Item.php
+++ b/tests/_support/Page/Item.php
@@ -27,6 +27,8 @@ class Item implements Context
 
         $I->getLastItemId();
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementVisible('#modalSpinner');
+        $I->waitForElementNotVisible('#modalSpinner');
 
         return $this;
     }

--- a/tests/_support/Page/Item.php
+++ b/tests/_support/Page/Item.php
@@ -27,7 +27,6 @@ class Item implements Context
 
         $I->getLastItemId();
         $I->amOnPage(self::$itemPath.$I->getItemId());
-        $I->waitForElementVisible('#modalSpinner');
         $I->waitForElementNotVisible('#modalSpinner');
 
         return $this;

--- a/tests/acceptance.suite.yml
+++ b/tests/acceptance.suite.yml
@@ -11,10 +11,10 @@ modules:
             cleanup: false
         - WebDriver:
             url: 'http://nginx/'
-            browser: phantomjs
-            host: 'phantomjs'
-            port: 8643
-            window_size: 'maximize'
+            browser: chrome
+            host: chrome
+            restart: true
+            window_size: 1500x1100
         - \Helper\Acceptance
         - \Helper\UserManagement
         - \Helper\Guzzle


### PR DESCRIPTION
PhantomJS does not support some of the newer Javascript methods that are desired.

This PR changes the default browser to chrome for the automated tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/215)
<!-- Reviewable:end -->
