### PR TITLE
Fixup comments testing

### DIFF
--- a/src/CftfBundle/Resources/views/DocTree/view.html.twig
+++ b/src/CftfBundle/Resources/views/DocTree/view.html.twig
@@ -5,7 +5,7 @@
 {% block stylesheets %}
     {{ parent() }}
     {% if 'comments' is active feature %}
-        <link rel="stylesheet" href="{{ asset('css/comments.css'|asset_version) }}" />
+        <link rel="stylesheet" href="{{ asset('build/commentscss.css', 'encore') }}" />
     {% endif %}
 {% endblock %}
 
@@ -440,9 +440,8 @@ header, footer {
 {% endblock %}
 
 {% block javascripts %}
-
 {% if 'comments' is active feature %}
-    <script src="{{ asset('js/comments.js'|asset_version) }}"></script>
+    <script src="{{ asset('build/comments.js', 'encore') }}"></script>
 {% endif %}
 
 {% autoescape 'js' %}

--- a/tests/acceptance/CommentDocCest.php
+++ b/tests/acceptance/CommentDocCest.php
@@ -22,6 +22,7 @@ class CommentDocCest
     {
         $I->getLastFrameworkId();
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->seeElement('.jquery-comments');
         $I->see('To comment please login first');
     }
@@ -30,6 +31,7 @@ class CommentDocCest
     {
         $I->getLastFrameworkId();
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->dontSeeElement('.jquery-comments .commenting-field');
         $I->see('To comment please login first');
     }
@@ -40,6 +42,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->seeElement('.commenting-field');
     }
 
@@ -49,6 +52,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('acceptance doc comment '.sq($I->getDocId()));
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance doc comment '.sq($I->getDocId()), '.comment-wrapper .wrapper .content');
@@ -56,6 +60,7 @@ class CommentDocCest
         // Verify a different user can see the comment
         $loginPage->logout();
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance doc comment '.sq($I->getDocId()), '.comment-wrapper .wrapper .content');
     }
@@ -64,6 +69,7 @@ class CommentDocCest
     {
         $I->getLastFrameworkId();
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->click(Locator::firstElement('.upvote'));
         $I->waitForJS('return $.active == 0;', 2);
         $I->seeCurrentUrlEquals('/login');
@@ -75,6 +81,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $upvotes = $I->grabTextFrom(Locator::firstElement('.upvote'));
         $I->click(Locator::firstElement('.upvote'));
         $I->waitForJS('return $.active == 0', 2);
@@ -87,6 +94,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('downvote doc comment '.sq($I->getDocId()));
         $I->waitForJS('return $.active == 0', 2);
         $I->click(Locator::firstElement('.upvote'));
@@ -103,6 +111,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Super User');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->click('#rightSideCopyItemsBtn');
         $I->waitForElement('#tree2Section');
         $I->dontSeeElement('js-comments-container');
@@ -114,6 +123,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Super User');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->click('#rightSideCreateAssociationsBtn');
         $I->waitForElement('#tree2Section');
         $I->dontSeeElement('js-comments-container');
@@ -125,6 +135,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('acceptance doc comment '.sq($I->getDocId()));
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance doc comment '.sq($I->getDocId()), '.comment-wrapper .wrapper .content');
@@ -141,6 +152,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('acceptance doc comment '.sq($I->getDocId()));
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance doc comment '.sq($I->getDocId()), '.comment-wrapper .wrapper .content');
@@ -148,6 +160,7 @@ class CommentDocCest
         $loginPage->logout();
         $loginPage->loginAsRole('Admin');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
         $upvotes = $I->grabTextFrom(Locator::firstElement('.upvote'));
 
@@ -158,6 +171,7 @@ class CommentDocCest
         $loginPage->logout();
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
 
         $I->click('.comment-wrapper .wrapper .actions .edit');
@@ -172,6 +186,7 @@ class CommentDocCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('acceptance doc replied comment '.sq($I->getDocId()));
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance doc replied comment '.sq($I->getDocId()), '.comment-wrapper .wrapper .content');
@@ -179,6 +194,7 @@ class CommentDocCest
         $loginPage->logout();
         $loginPage->loginAsRole('Admin');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
 
         $I->click(Locator::firstElement('.reply'));
@@ -189,6 +205,7 @@ class CommentDocCest
         $loginPage->logout();
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
 
         $I->click('.comment-wrapper .wrapper .actions .edit');

--- a/tests/acceptance/CommentItemCest.php
+++ b/tests/acceptance/CommentItemCest.php
@@ -22,6 +22,7 @@ class CommentItemCest
     {
         $I->getLastFrameworkId();
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->seeElement('.jquery-comments');
         $I->see('To comment please login first');
     }
@@ -30,6 +31,7 @@ class CommentItemCest
     {
         $I->getLastFrameworkId();
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->dontSeeElement('.jquery-comments .commenting-field');
         $I->see('To comment please login first');
     }
@@ -40,6 +42,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->seeElement('.commenting-field');
     }
 
@@ -49,6 +52,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('acceptance item comment '.sq($I->getItemId()));
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance item comment '.sq($I->getItemId()), '.comment-wrapper .wrapper .content');
@@ -56,6 +60,7 @@ class CommentItemCest
         // Verify a different user can see the comment
         $loginPage->logout();
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance item comment '.sq($I->getItemId()), '.comment-wrapper .wrapper .content');
     }
@@ -64,6 +69,7 @@ class CommentItemCest
     {
         $I->getLastFrameworkId();
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->click(Locator::firstElement('.upvote'));
         $I->waitForJS('return $.active == 0;', 2);
         $I->seeCurrentUrlEquals('/login');
@@ -75,6 +81,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $upvotes = $I->grabTextFrom(Locator::firstElement('.upvote'));
         $I->click(Locator::firstElement('.upvote'));
         $I->waitForJS('return $.active == 0', 2);
@@ -87,6 +94,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('downvote comment '.sq($I->getItemId()));
         $I->waitForJS('return $.active == 0', 2);
         $I->click(Locator::firstElement('.upvote'));
@@ -103,6 +111,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Super User');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->click('#rightSideCopyItemsBtn');
         $I->waitForElement('#tree2Section');
         $I->dontSeeElement('js-comments-container');
@@ -114,6 +123,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Super User');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->click('#rightSideCreateAssociationsBtn');
         $I->waitForElement('#tree2Section');
         $I->dontSeeElement('js-comments-container');
@@ -125,6 +135,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('acceptance doc comment '.sq($I->getItemId()));
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance doc comment '.sq($I->getItemId()), '.comment-wrapper .wrapper .content');
@@ -141,6 +152,7 @@ class CommentItemCest
         $loginPage = new \Page\Login($I);
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->createAComment('acceptance doc comment '.sq($I->getItemId()));
         $I->waitForJS('return $.active == 0;', 2);
         $I->see('acceptance doc comment '.sq($I->getItemId()), '.comment-wrapper .wrapper .content');
@@ -148,6 +160,7 @@ class CommentItemCest
         $loginPage->logout();
         $loginPage->loginAsRole('Admin');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
         $upvotes = $I->grabTextFrom(Locator::firstElement('.upvote'));
 
@@ -158,6 +171,7 @@ class CommentItemCest
         $loginPage->logout();
         $loginPage->loginAsRole('Editor');
         $I->amOnPage(self::$itemPath.$I->getItemId());
+        $I->waitForElementNotVisible('#modalSpinner', 120);
         $I->waitForJS('return $.active == 0;', 2);
 
         $I->click('.comment-wrapper .wrapper .actions .edit');


### PR DESCRIPTION
a) Load comment code correctly now that we are using webpack
b) For the tests, add a wait for the spinner to go away before trying to access the page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/224)
<!-- Reviewable:end -->
