### PR TITLE
Removed createRights

### DIFF
--- a/src/CftfBundle/Resources/views/DocTree/view.html.twig
+++ b/src/CftfBundle/Resources/views/DocTree/view.html.twig
@@ -164,7 +164,7 @@ header, footer {
                                     <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#addNewChildModal" data-alt-document-disabled="true">Add New Child Item</button>
                                 {% endif %}
 
-                                {% if createRights %}
+                                {% if editorRights %}
                                     {% if isDraft %}
                                         <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#addChildrenModal" data-alt-document-disabled="true">Import Children</button>
                                         <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#updateFrameworkModal" data-alt-document-disabled="true">Update Framework</button>


### PR DESCRIPTION
I don’t see ‘createRights’ anywhere else except here so replaced it with editorRights:
https://github.com/opensalt/opensalt/blob/c71e91120f3201634b4fd7052397c6
a3b85bf13e/src/CftfBundle/Controller/DocTreeController.php. Perhaps it
is obsolete?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/269)
<!-- Reviewable:end -->
