### PR TITLE
Clicking lock expiry warning notification should close it

### DIFF
--- a/app/Resources/assets/js/cftree/viewx.js
+++ b/app/Resources/assets/js/cftree/viewx.js
@@ -668,7 +668,7 @@ $.extend(apx.notifications, {
                     });
                 }, timeout - warningTime, id);
 
-                apx.locks.mine.items[id] = {
+                apx.locks.mine.docs[id] = {
                     warning: warning,
                     timeout: msg.at + timeout + apx.timeDiff - 2000
                 };
@@ -804,13 +804,13 @@ $.extend(apx.notifications, {
             return;
         }
 
-        if ('undefined' !== typeof msg.msgId && 'function' === typeof apx.notifyCheck[msg.msgId]) {
+        if ('function' === typeof apx.notifyCheck[msg.msgId]) {
             if (false === apx.notifyCheck[msg.msgId](msg)) {
                 return;
             }
         }
 
-        if (msg.url) {
+        if (msg.url && "LockTimeoutWarning" !== msg.msgId) {
             msg.msg += '<span class="notification-url-indicator">Show</span>';
         }
 


### PR DESCRIPTION
Clicking on the lock expiry warning notification should close the notication box and reset the expiry time.

This is a fix for an issue discovered in the way that locks for documents are handled in the javascript for the new notification feature.

ref: SALT-36, SALT-37

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/338)
<!-- Reviewable:end -->
