### PR TITLE
fix: add default CREATE_ACCOUNT_FEATURE env var

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -29,8 +29,10 @@ parameters:
 
     env(GITHUB_CLIENT_ID): ~
     env(GITHUB_CLIENT_SECRET): ~
+
     # to enable the comments feature you should pass 'always-active' instead of 'inactive'
     env(COMMENTS_FEATURE): inactive
+    env(CREATE_ACCOUNT_FEATURE): inactive
 
     env(BRAND_LOGO_URL): ~
     env(BRAND_LOGO_STYLE): ~

--- a/app/config/parameters.yml.no-env
+++ b/app/config/parameters.yml.no-env
@@ -23,8 +23,10 @@ parameters:
 
     env(GITHUB_CLIENT_ID): ~
     env(GITHUB_CLIENT_SECRET): ~
+
     # to enable the comments feature you should pass 'always-active' instead of 'inactive'
     env(COMMENTS_FEATURE): inactive
+    env(CREATE_ACCOUNT_FEATURE): inactive
 
     env(BRAND_LOGO_URL): ~
     env(BRAND_LOGO_STYLE): ~


### PR DESCRIPTION
PR #355 added a new feature (Create Account), but an error will occur if the new environment variable is not passed.

This PR adds a default parameter for env(CREATE_ACCOUNT_FEATURE)  in case it is not passed in the environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/361)
<!-- Reviewable:end -->
