### PR TITLE
fix: hide tree view when other tabs selected

### DIFF
--- a/src/CftfBundle/Resources/views/DocTree/view.html.twig
+++ b/src/CftfBundle/Resources/views/DocTree/view.html.twig
@@ -43,7 +43,7 @@
         {% endif %}
     </div>
 
-    <div id="treeView" style="display:none; width:100%">
+    <div class="main-view tree-view" id="treeView" style="display:none; width:100%">
         <div id="treeSideLeft" class="treeSide borderLeft">
 
             <div class="treeSideLeftInner">

--- a/tests/_support/Page/FrameworkLogs.php
+++ b/tests/_support/Page/FrameworkLogs.php
@@ -24,6 +24,7 @@ class FrameworkLogs implements Context
     public function iSeeTheLogTable()
     {
         $this->I->seeElement('table#logTable');
+        $this->I->dontSeeElement('#treeView');
     }
 
     /**


### PR DESCRIPTION
Revert change made to [view.html.twig](https://github.com/opensalt/opensalt/commit/cf99696a9d5e0797944a22cbc5259af88d614bbe#diff-78c96ec04b81abc49ef7ce970ba8a650L46) in commit cf99696a9d5e0797944a22cbc5259af88d614bbe (part of PR #331) to add the main-view and tree-view classes back on the tree view div

resolves #362

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/370)
<!-- Reviewable:end -->
