### PR TITLE
fix: allow no email "from" address to be configured

### DIFF
--- a/src/App/Handler/Email/AbstractEmailHandler.php
+++ b/src/App/Handler/Email/AbstractEmailHandler.php
@@ -36,7 +36,7 @@ abstract class AbstractEmailHandler extends BaseValidatedHandler implements Even
      */
     private $mailFromEmail;
 
-    public function __construct(ValidatorInterface $validator, ToggleManager $manager, ContextFactory $contextFactory, \Swift_Mailer $mailer, string $mailFromEmail)
+    public function __construct(ValidatorInterface $validator, ToggleManager $manager, ContextFactory $contextFactory, \Swift_Mailer $mailer, string $mailFromEmail = null)
     {
         parent::__construct($validator);
         $this->manager = $manager;


### PR DESCRIPTION
Fix the email handler so that it will not cause an error if no address is set for the *MAIL_FEATURE_FROM_EMAIL* environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/379)
<!-- Reviewable:end -->
