### PR TITLE
fix: use double quotes around filename in content-disposition header

### DIFF
--- a/src/App/Controller/ExcelExportController.php
+++ b/src/App/Controller/ExcelExportController.php
@@ -41,7 +41,7 @@ class ExcelExportController extends Controller
             200,
             [
                 'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                'Content-Disposition' => "attachment;filename='{$title}.xlsx'",
+                'Content-Disposition' => 'attachment; filename="'.$title.'.xlsx"',
                 'Cache-Control' => 'max-age=0',
             ]
         );

--- a/src/CftfBundle/Controller/CfPackageController.php
+++ b/src/CftfBundle/Controller/CfPackageController.php
@@ -44,7 +44,7 @@ class CfPackageController extends Controller
             ));
 
             $response->headers->set('Content-Type', 'application/json');
-            $response->headers->set('Content-Disposition', 'attachment; filename=opensalt-framework-'.$lsDoc->getIdentifier().'.json');
+            $response->headers->set('Content-Disposition', 'attachment; filename="opensalt-framework-'.$lsDoc->getIdentifier().'.json"');
 
             return $response;
         }


### PR DESCRIPTION
For the content-disposition header, use double quotes around the
filename as the spec requires a quoted-string.

resolves #313