### PR TITLE
change to using flex display for the left tree

### DIFF
--- a/app/Resources/assets/sass/cftree/view.scss
+++ b/app/Resources/assets/sass/cftree/view.scss
@@ -30,6 +30,8 @@ body{
     height: calc(100vh - 243px);
     overflow: hidden;
     float:left;
+    display: flex;
+    flex-flow: column;
 }
 
 .treeSideRightInner {
@@ -63,13 +65,10 @@ body{
 }
 
 #tree1Section {
-    height: calc(100% - 169px);
+    flex: 1 1 auto;
     overflow:auto;
     padding:3px;
     border-width:0;
-}
-.assocGroupFilter[style="display:none"] ~ #tree1Section {
-    height: calc(100% - 122px);
 }
 
 #tree1Section.otherDoc .fancytree-container {

--- a/app/Resources/views/framework/doc_tree/view.html.twig
+++ b/app/Resources/views/framework/doc_tree/view.html.twig
@@ -212,31 +212,19 @@
                                             <a href="{{ path('framework_acl_edit', {'id':lsDocId}) }}" class="btn btn-default btn-sm" data-alt-document-disabled="true">Manage Access</a>
                                         {% endif %}
 
-                                        {% if editorRights and isDraft %}
-                                            <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#addNewChildModal" data-alt-document-disabled="true">
-                                                Add New Child Item
-                                            </button>
-                                            <button type="button" class="btn btn-default btn-sm" data-toggle="modal"
-                                                    data-target="#addChildrenModal"
-                                                    data-alt-document-disabled="true">Import Children
-                                            </button>
-                                            <button type="button" class="btn btn-default btn-sm" data-toggle="modal"
-                                                    data-target="#updateFrameworkModal"
-                                                    data-alt-document-disabled="true">Update Framework
-                                            </button>
-                                            <button type="button" id="js-copy-framework-modal-button" class="btn btn-default btn-sm" data-toggle="modal"
-                                                    data-target="#copyFrameworkModal"
-                                                    data-alt-document-disabled="true">Copy Framework
-                                            </button>
-                                        {% endif %}
-
                                         {% if editorRights %}
                                             {% if isDraft %}
+                                                <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#addNewChildModal" data-alt-document-disabled="true">
+                                                    Add New Child Item
+                                                </button>
                                                 <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#addChildrenModal" data-alt-document-disabled="true">
                                                     Import Children
                                                 </button>
                                                 <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#updateFrameworkModal" data-alt-document-disabled="true">
                                                     Update Framework
+                                                </button>
+                                                <button type="button" id="js-copy-framework-modal-button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#copyFrameworkModal" data-alt-document-disabled="true">
+                                                    Copy Framework
                                                 </button>
                                             {% endif %}
                                             {% if lsDoc.importLogs is not empty %}


### PR DESCRIPTION
Use `display: flex` for the left tree area so that we can have it expand to the full height.

fixes #227

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/430)
<!-- Reviewable:end -->
