### PR TITLE
use an "OpenSALT" version of the node docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,14 +63,14 @@ js: encore cache-clear
 .PHONY: js
 
 encore: yarn-install
-	docker run --rm -u $(shell id -u):$(shell id -g) -v $(shell pwd):/app --workdir /app node:alpine ./node_modules/.bin/encore production
+	docker run --rm -u $(shell id -u):$(shell id -g) -v $(shell pwd):/app --workdir /app opensalt/node:alpine ./node_modules/.bin/encore production
 encore-dev: yarn-install
-	docker run --rm -u $(shell id -u):$(shell id -g) -v $(shell pwd):/app --workdir /app node:alpine ./node_modules/.bin/encore dev
+	docker run --rm -u $(shell id -u):$(shell id -g) -v $(shell pwd):/app --workdir /app opensalt/node:alpine ./node_modules/.bin/encore dev
 encore-build: encore
 .PHONY: encore encore-dev encore-build
 
 node_modules: yarn.lock package.json
-	docker run --rm -u $(shell id -u):$(shell id -g) -v $(shell pwd):/app --workdir /app node:alpine yarn install --non-interactive
+	docker run --rm -u $(shell id -u):$(shell id -g) -v $(shell pwd):/app --workdir /app opensalt/node:alpine yarn install --non-interactive
 yarn-install: node_modules
 .PHONY: yarn-install
 

--- a/bin/encore
+++ b/bin/encore
@@ -2,10 +2,10 @@
 
 cd $(dirname $0)/..
 
-docker pull node:alpine
+docker pull opensalt/node:alpine
 
 # Install node modules
-docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app --workdir /app node:alpine yarn install --non-interactive
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app --workdir /app opensalt/node:alpine yarn install --non-interactive
 
 # Build js
-docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app --workdir /app node:alpine ./node_modules/.bin/encore "$@"
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app --workdir /app opensalt/node:alpine ./node_modules/.bin/encore "$@"

--- a/bin/yarn
+++ b/bin/yarn
@@ -2,7 +2,7 @@
 
 cd $(dirname $0)/..
 
-docker pull node:alpine
+docker pull opensalt/node:alpine
 
 # Install node modules
-docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app --workdir /app -it node:alpine yarn "$@"
+docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app --workdir /app -it opensalt/node:alpine yarn "$@"


### PR DESCRIPTION
Due to the issues we ran into this morning with the bug in the official `node:alpine` docker image, use a forked image that we have more control over (at least temporarily).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/431)
<!-- Reviewable:end -->
