### PR TITLE
Password should be 8 characters long  (KMS-3807)

### DIFF
--- a/src/Controller/User/SignupController.php
+++ b/src/Controller/User/SignupController.php
@@ -134,7 +134,7 @@ class SignupController extends AbstractController
                 if ('dev' === $this->kernelEnv) {
                     $form->addError(new FormError(get_class($e).': '.$e->getMessage()));
                 } else {
-                    $form->addError(new FormError('Sorry, Passwords must be at least 8 characters long.'));
+                    $form->addError(new FormError('Sorry, an error occurred while creating your account.'));
                 }
             }
         }

--- a/src/Controller/User/SignupController.php
+++ b/src/Controller/User/SignupController.php
@@ -134,7 +134,7 @@ class SignupController extends AbstractController
                 if ('dev' === $this->kernelEnv) {
                     $form->addError(new FormError(get_class($e).': '.$e->getMessage()));
                 } else {
-                    $form->addError(new FormError('Sorry, an error occurred while creating your account.'));
+                    $form->addError(new FormError('Sorry, Passwords must be at least 8 characters long.'));
                 }
             }
         }

--- a/src/Entity/User/User.php
+++ b/src/Entity/User/User.php
@@ -70,7 +70,8 @@ class User implements AdvancedUserInterface, \Serializable, EquatableInterface
      *      min=8,
      *      max=4096,
      *      minMessage="Password must be at least {{ limit }} charactes long",
-     *      maxMessage="Password cannot be longer than {{ limit }} characters"
+     *      maxMessage="Password cannot be longer than {{ limit }} characters",
+     *      groups={"registration"}
      *  )
      * @CustomAssert\PasswordField(groups={"registration"})
      */

--- a/tests/acceptance/features/user/public_user/password_length_eight_char.feature
+++ b/tests/acceptance/features/user/public_user/password_length_eight_char.feature
@@ -1,0 +1,41 @@
+
+Feature: Create new account password should be 8 characters long
+
+    @public-user @user @add-user
+    Scenario: Must match passwords
+        Given "create_account" is enabled
+        And I am on the homepage
+        And I follow "Sign up"
+
+        Then I should see "Create new account"
+        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Password" with "Password123!"
+        Then I fill in the "Confirm Password" with "password"
+        Then I click "Submit"
+        Then I should see "Passwords do not match"
+
+    @public-user @user @add-user
+    Scenario: Must be a valid password
+        Given "create_account" is enabled
+        And I am on the homepage
+        And I follow "Sign up"
+
+        Then I should see "Create new account"
+        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Password" with "password"
+        Then I fill in the "Confirm Password" with "password"
+        Then I click "Submit"
+        Then I should see "Password does not match required criteria"
+
+    @public-user @user @add-user
+    Scenario: Password must be 8 characters long
+        Given "create_account" is enabled
+        And I am on the homepage
+        And I follow "Sign up"
+
+        Then I should see "Create new account"
+        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Password" with "pass@1"
+        Then I fill in the "Confirm Password" with "pass@1"
+        Then I click "Submit"
+        Then I should see "Sorry, Passwords must be at least 8 characters long." 

--- a/tests/acceptance/features/user/public_user/password_length_eight_char.feature
+++ b/tests/acceptance/features/user/public_user/password_length_eight_char.feature
@@ -27,7 +27,7 @@ Feature: Create new user account password should be 8 characters long
         Then I should see "Password does not match required criteria"
 
     @public-user @user @add-user @5568-7622
-    Scenario: 5568-7622 Password must be 8 characters long
+    Scenario: 5569-7622 Password must be 8 characters long
         Given "create_account" is enabled
         And I am on the homepage
         And I follow "Sign up"

--- a/tests/acceptance/features/user/public_user/password_length_eight_char.feature
+++ b/tests/acceptance/features/user/public_user/password_length_eight_char.feature
@@ -1,4 +1,4 @@
-Feature: Create new account password should be 8 characters long
+Feature: Create new user account password should be 8 characters long
 
     @public-user @user @add-user @5566-7620
     Scenario: 5566-7620 Must match passwords
@@ -14,7 +14,7 @@ Feature: Create new account password should be 8 characters long
         Then I should see "Passwords do not match"
 
     @public-user @user @add-user @5567-7621
-    Scenario: 5566-7621 Must be a valid password
+    Scenario: 5567-7621 Must be a valid password
         Given "create_account" is enabled
         And I am on the homepage
         And I follow "Sign up"

--- a/tests/acceptance/features/user/public_user/password_length_eight_char.feature
+++ b/tests/acceptance/features/user/public_user/password_length_eight_char.feature
@@ -1,8 +1,7 @@
-
 Feature: Create new account password should be 8 characters long
 
-    @public-user @user @add-user
-    Scenario: Must match passwords
+    @public-user @user @add-user @5566-7620
+    Scenario: 5566-7620 Must match passwords
         Given "create_account" is enabled
         And I am on the homepage
         And I follow "Sign up"
@@ -14,8 +13,8 @@ Feature: Create new account password should be 8 characters long
         Then I click "Submit"
         Then I should see "Passwords do not match"
 
-    @public-user @user @add-user
-    Scenario: Must be a valid password
+    @public-user @user @add-user @5567-7621
+    Scenario: 5566-7621 Must be a valid password
         Given "create_account" is enabled
         And I am on the homepage
         And I follow "Sign up"
@@ -27,8 +26,8 @@ Feature: Create new account password should be 8 characters long
         Then I click "Submit"
         Then I should see "Password does not match required criteria"
 
-    @public-user @user @add-user
-    Scenario: Password must be 8 characters long
+    @public-user @user @add-user @5568-7622
+    Scenario: 5568-7622 Password must be 8 characters long
         Given "create_account" is enabled
         And I am on the homepage
         And I follow "Sign up"
@@ -38,4 +37,4 @@ Feature: Create new account password should be 8 characters long
         Then I fill in the "Password" with "pass@1"
         Then I fill in the "Confirm Password" with "pass@1"
         Then I click "Submit"
-        Then I should see "Sorry, Passwords must be at least 8 characters long." 
+        Then I should see "Sorry, Passwords must be at least 8 characters long."


### PR DESCRIPTION
Display the error message "Passwords must be at least 8 characters long" .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/445)
<!-- Reviewable:end -->
