### PR TITLE
Change password criteria is not working properly (KMS-4225)

### DIFF
--- a/src/Controller/User/ChangePasswordController.php
+++ b/src/Controller/User/ChangePasswordController.php
@@ -43,7 +43,7 @@ class ChangePasswordController extends AbstractController
     public function changePasswordAction(Request $request)
     {
         $dto = new ChangePasswordDTO();
-        $form = $this->createForm(ChangePasswordType::class, $dto);
+        $form = $this->createForm(ChangePasswordType::class, $dto, ['validation_groups' => ['registration']]);
 
         $form->handleRequest($request);
 

--- a/src/Controller/User/ChangePasswordController.php
+++ b/src/Controller/User/ChangePasswordController.php
@@ -43,7 +43,7 @@ class ChangePasswordController extends AbstractController
     public function changePasswordAction(Request $request)
     {
         $dto = new ChangePasswordDTO();
-        $form = $this->createForm(ChangePasswordType::class, $dto, ['validation_groups' => ['registration']]);
+        $form = $this->createForm(ChangePasswordType::class, $dto, ['validation_groups' => ['changepass']]);
 
         $form->handleRequest($request);
 

--- a/src/Controller/User/UserController.php
+++ b/src/Controller/User/UserController.php
@@ -154,7 +154,7 @@ class UserController extends AbstractController
     public function editAction(Request $request, User $targetUser)
     {
         $deleteForm = $this->createDeleteForm($targetUser);
-        $editForm = $this->createForm(UserType::class, $targetUser, ['validation_groups' => ['registration']]);
+        $editForm = $this->createForm(UserType::class, $targetUser);
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {

--- a/src/Controller/User/UserController.php
+++ b/src/Controller/User/UserController.php
@@ -86,7 +86,7 @@ class UserController extends AbstractController
     public function newAction(Request $request)
     {
         $targetUser = new User();
-        $form = $this->createForm(UserType::class, $targetUser, ['validation_groups' => ['registration']]);
+        $form = $this->createForm(UserType::class, $targetUser);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -154,7 +154,7 @@ class UserController extends AbstractController
     public function editAction(Request $request, User $targetUser)
     {
         $deleteForm = $this->createDeleteForm($targetUser);
-        $editForm = $this->createForm(UserType::class, $targetUser);
+        $editForm = $this->createForm(UserType::class, $targetUser, ['validation_groups' => ['registration']]);
         $editForm->handleRequest($request);
 
         if ($editForm->isSubmitted() && $editForm->isValid()) {

--- a/src/Controller/User/UserController.php
+++ b/src/Controller/User/UserController.php
@@ -86,7 +86,7 @@ class UserController extends AbstractController
     public function newAction(Request $request)
     {
         $targetUser = new User();
-        $form = $this->createForm(UserType::class, $targetUser);
+        $form = $this->createForm(UserType::class, $targetUser, ['validation_groups' => ['registration']]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Form/DTO/ChangePasswordDTO.php
+++ b/src/Form/DTO/ChangePasswordDTO.php
@@ -11,7 +11,7 @@ class ChangePasswordDTO
     /**
      * @var string
      *
-     * @SecurityAssert\UserPassword(message="The current password is incorrect", groups={"registration"})
+     * @SecurityAssert\UserPassword(message="The current password is incorrect", groups={"changepass"})
      */
     public $oldPassword;
 
@@ -23,9 +23,9 @@ class ChangePasswordDTO
      *      max=4096,
      *      minMessage="Password must be at least {{ limit }} characters long",
      *      maxMessage="Password cannot be longer than {{ limit }} characters",
-     *      groups={"registration"} 
+     *      groups={"changepass"} 
      * )
-     * @CustomAssert\PasswordField(groups={"registration"})
+     * @CustomAssert\PasswordField(groups={"changepass"})
      * 
      */
     public $newPassword;

--- a/src/Form/DTO/ChangePasswordDTO.php
+++ b/src/Form/DTO/ChangePasswordDTO.php
@@ -4,13 +4,14 @@ namespace App\Form\DTO;
 
 use Symfony\Component\Security\Core\Validator\Constraints as SecurityAssert;
 use Symfony\Component\Validator\Constraints as Assert;
+use App\Validator\Constraints as CustomAssert;
 
 class ChangePasswordDTO
 {
     /**
      * @var string
      *
-     * @SecurityAssert\UserPassword(message="The current password is incorrect")
+     * @SecurityAssert\UserPassword(message="The current password is incorrect", groups={"registration"})
      */
     public $oldPassword;
 
@@ -18,9 +19,14 @@ class ChangePasswordDTO
      * @var string
      *
      * @Assert\Length(
-     *     min = 6,
-     *     minMessage="The new password should be at least 6 characters long"
+     *      min=8,
+     *      max=4096,
+     *      minMessage="Password must be at least {{ limit }} characters long",
+     *      maxMessage="Password cannot be longer than {{ limit }} characters",
+     *      groups={"registration"} 
      * )
+     * @CustomAssert\PasswordField(groups={"registration"})
+     * 
      */
     public $newPassword;
 }

--- a/src/Form/Type/ChangePasswordType.php
+++ b/src/Form/Type/ChangePasswordType.php
@@ -18,7 +18,7 @@ class ChangePasswordType extends AbstractType
             ->add('newPassword', RepeatedType::class, [
                 'type' => PasswordType::class,
                 'invalid_message' => 'The password fields must match',
-                'required' => true,
+                'required' => in_array('registration', $options['validation_groups'], true),
                 'first_options' => [
                     'label' => 'New Password',
                 ],

--- a/src/Form/Type/ChangePasswordType.php
+++ b/src/Form/Type/ChangePasswordType.php
@@ -18,7 +18,7 @@ class ChangePasswordType extends AbstractType
             ->add('newPassword', RepeatedType::class, [
                 'type' => PasswordType::class,
                 'invalid_message' => 'The password fields must match',
-                'required' => in_array('registration', $options['validation_groups'], true),
+                'required' => in_array('changepass', $options['validation_groups'], true),
                 'first_options' => [
                     'label' => 'New Password',
                 ],
@@ -32,6 +32,7 @@ class ChangePasswordType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => ChangePasswordDTO::class,
+            'validation_groups' => ['Default'],
         ]);
     }
 }

--- a/tests/_support/Page/User.php
+++ b/tests/_support/Page/User.php
@@ -233,14 +233,14 @@ class User implements Context
         $I->amOnPage('/user/change-password');
         $I->see('Change Password');
         $I->fillField('#change_password_oldPassword', $password);
-        $I->fillField('#change_password_newPassword_first', '123456');
-        $I->fillField('#change_password_newPassword_second', '123456');
+        $I->fillField('#change_password_newPassword_first', 'opensalt@123');
+        $I->fillField('#change_password_newPassword_second', 'opensalt@123');
         $I->click('/html/body/div[1]/main/div[2]/div/div[2]/form/ul/li[1]/input');
         $I->see('Your password has been changed.');
 
         $I->amOnPage('/user/change-password');
         $I->see('Change Password');
-        $I->fillField('#change_password_oldPassword', '123456');
+        $I->fillField('#change_password_oldPassword', 'opensalt@123');
         $I->fillField('#change_password_newPassword_first', $password);
         $I->fillField('#change_password_newPassword_second', $password);
         $I->click('/html/body/div[1]/main/div[2]/div/div[2]/form/ul/li[1]/input');
@@ -343,5 +343,19 @@ class User implements Context
         $I->amOnPage('/admin/user');
         $I->click('th.sorting_asc');
         $I->assertEquals($I->grabTextFrom('//*[@id="datatable"]/tbody/tr[1]/td[5]'), 'Pending', 'Can not see status column');
+    }
+    
+    /**
+     * @Then /^I fill in the old password$/
+     */
+    public function iOldPassword()
+    {
+        $I = $this->I;
+        $password = $this->I->getLastPassword();
+
+        $I->amOnPage('/user/change-password');
+        $I->see('Change Password');
+        $I->fillField('#change_password_oldPassword', $password);
+
     }
 }

--- a/tests/acceptance/features/user/organization_admin/password_change_criteria.feature
+++ b/tests/acceptance/features/user/organization_admin/password_change_criteria.feature
@@ -1,0 +1,30 @@
+Feature: Password change validations
+    In order to change my password
+    As an organization admin
+    I need to put in a new password
+
+    @admin @user @password @8923-8924
+    Scenario: Must match passwords
+        Given I log in as a user with role "Admin"
+
+        Then I fill in the old password
+        Then I fill in the "New Password" with "opensalt"
+        Then I fill in the "Repeat Password" with "opensal"
+        Then I click "Change Password"
+        Then I should see "The password fields must match" 
+
+    @admin @user @password @8929-8930 
+    Scenario: Must be 8 char long  passwords
+        Given I log in as a user with role "Admin"
+
+        Then I fill in the old password
+        Then I fill in the "New Password" with "open"
+        Then I fill in the "Repeat Password" with "open"
+        Then I click "Change Password"
+        Then I should see "Password must be at least 8 characters long"
+        Then I should see "Password does not match required criteria"
+
+    @admin @user @password @1011-0905
+    Scenario: 1011-0905 Changing my Password
+      Given I log in as a user with role "Admin"
+      Then I change my password


### PR DESCRIPTION
Reset password criteria is not working properly when trying to reset the password from User Management screen.
1- Login by the Super User.
2- Manage user - select edit button from any user from the list.
3- User edit window - try to change the password without password criteria.

Login in opensalt with any user .
1. click the right side tab(ex:abc@gmail.com)
2. than click the change password link.
3. insert the old password , New Password and Repeat Password.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/482)
<!-- Reviewable:end -->
