### PR TITLE
Update PDF Exporter with Images

### DIFF
--- a/app/Resources/views/framework/doc_tree/export_pdf.html.twig
+++ b/app/Resources/views/framework/doc_tree/export_pdf.html.twig
@@ -17,7 +17,7 @@
 {% for category in pdfData.CFItems %}
 
     <section>
-       <p><b>Full Statement : </b>{{ category.fullStatement }} </p>
+       <p><b>Full Statement : </b>{{ category.fullStatement | raw }} </p>
        {% if category.humanCodingScheme is defined %}<p><b>Human coding scheme : </b>{{ category.humanCodingScheme }} </p>{% endif %}
        {% if category.listEnumeration is defined %}<p><b>List enum in source : </b>{{ category.listEnumeration }} </p>{% endif %}
        {% if category.abbreviatedStatement is defined %}<p><b>Abbreviated statement : </b>{{ category.abbreviatedStatement }} </p>{% endif %}
@@ -25,7 +25,7 @@
        {% if category.language is defined %}<p><b>Language : </b>{{ category.language }} </p>{% endif %}
        {% if category.educationLevel is defined %}<p><b>Education Level : </b>{% for level in category.educationLevel %}{% if not loop.first %}, {% endif %}{{ level }} {% endfor %} </p>{% endif %}
        {% if category.CFItemType is defined %}<p><b>Item type : </b>{{ category.CFItemType }} </p>{% endif %}
-       {% if category.notes is defined %}<p><b>Notes : </b>{{ category.notes }} </p> {% endif %}
+       {% if category.notes is defined %}<p><b>Notes : </b>{{ category.notes | raw }} </p> {% endif %}
     </section>
 
     <section>

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -69,7 +69,7 @@ class PdfExportController extends Controller
      */
     public function render_images($string)
     {
-        $pattern = '/\!\[([^\]]*)alt text\]\(*\((\b(?:(?:https?|ftp):\/\/|www\.)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|])\)/';
+        $pattern = '/\!\[([^\]]*)\]\(((?:https:\/\/|\/)[^\)]+)\)/';
         $result = preg_replace($pattern, '$1 <img src = "$2">', $string);
         return $result;
     }

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -31,7 +31,7 @@ class PdfExportController extends Controller
 
         $response = $this->forward('App\Controller\Framework\CfPackageController:exportAction', ['id' => $id, '_format' => 'json']);
         $data_array=json_decode($response->getContent(), true);
-        for($i=0; $i < sizeof($data_array['CFItems']); ++$i)
+        for($i=0; $i < count($data_array['CFItems']); ++$i)
         {
             $data_array['CFItems'][$i]['fullStatement']= $this->render_images($data_array['CFItems'][$i]['fullStatement']);
             if(isset($data_array['CFItems'][$i]['notes']))

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -70,7 +70,7 @@ class PdfExportController extends Controller
     public function render_images($string)
     {
         $pattern = '/\!\[([^\]]*)alt text\]\(*\((\b(?:(?:https?|ftp):\/\/|www\.)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|])\)/';
-        $result = preg_replace($pattern, '$1 <img src = "$2">', $string );
+        $result = preg_replace($pattern, '$1 <img src = "$2">', $string);
         return $result;
     }
 }

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -30,9 +30,19 @@ class PdfExportController extends Controller
         $section = $phpWordObject->addSection();
 
         $response = $this->forward('App\Controller\Framework\CfPackageController:exportAction', ['id' => $id, '_format' => 'json']);
+        $data_array=json_decode($response->getContent(), true);
+        for($i=0; $i < sizeof($data_array['CFItems']); $i++)
+        {
+            $data_array['CFItems'][$i]['fullStatement']= $this->render_images($data_array['CFItems'][$i]['fullStatement']);
+            if(isset($data_array['CFItems'][$i]['notes']))
+            {
+                $data_array['CFItems'][$i]['notes']= $this->render_images($data_array['CFItems'][$i]['notes']);
+            }
+       }
         $html = $this->renderView(
             'framework/doc_tree/export_pdf.html.twig',
-            ['pdfData' => json_decode($response->getContent(), true)]
+            ['pdfData' => $data_array]
+            
         );
         Html::addHtml($section, htmlentities($html));
         Settings::setPdfRendererName(Settings::PDF_RENDERER_TCPDF);
@@ -51,5 +61,18 @@ class PdfExportController extends Controller
                 'Cache-Control' => 'max-age=0',
             ]
         );
+    }
+
+    /**
+     *
+     * @param string $string
+     *
+     * @return result
+     */
+    public function render_images($string)
+    {
+        $string = str_replace('![alt text](', '<br/><br/><img src ="', $string);
+        $result = str_replace(')', '"/>', $string);
+        return $result;
     }
 }

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -70,7 +70,7 @@ class PdfExportController extends Controller
     public function render_images($string)
     {
         $pattern = '/\!\[([^\]]*)alt text\]\(*\((\b(?:(?:https?|ftp):\/\/|www\.)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|])\)/';
-        $result = preg_replace($pattern, '$1 <img src="$2">' , $string );
+        $result = preg_replace($pattern, '$1 <img src = "$2">', $string );
         return $result;
     }
 }

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -69,8 +69,8 @@ class PdfExportController extends Controller
      */
     public function render_images($string)
     {
-        $string = str_replace('![alt text](', '<br/><br/><img src ="', $string);
-        $result = str_replace(')', '"/>', $string);
+        $pattern = '/\!\[([^\]]*)alt text\]\(*\((\b(?:(?:https?|ftp):\/\/|www\.)[-a-z0-9+&@#\/%?=~_|!:,.;]*[-a-z0-9+&@#\/%=~_|])\)/';
+        $result = preg_replace($pattern, '$1 <img src="$2">' , $string );
         return $result;
     }
 }

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -31,7 +31,7 @@ class PdfExportController extends Controller
 
         $response = $this->forward('App\Controller\Framework\CfPackageController:exportAction', ['id' => $id, '_format' => 'json']);
         $data_array=json_decode($response->getContent(), true);
-        for($i=0; $i < sizeof($data_array['CFItems']); $i++)
+        for($i=0; $i < sizeof($data_array['CFItems']); ++$i)
         {
             $data_array['CFItems'][$i]['fullStatement']= $this->render_images($data_array['CFItems'][$i]['fullStatement']);
             if(isset($data_array['CFItems'][$i]['notes']))
@@ -42,7 +42,6 @@ class PdfExportController extends Controller
         $html = $this->renderView(
             'framework/doc_tree/export_pdf.html.twig',
             ['pdfData' => $data_array]
-            
         );
         Html::addHtml($section, htmlentities($html));
         Settings::setPdfRendererName(Settings::PDF_RENDERER_TCPDF);
@@ -64,7 +63,6 @@ class PdfExportController extends Controller
     }
 
     /**
-     *
      * @param string $string
      *
      * @return result

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -1185,6 +1185,7 @@ class Framework implements Context
         $writer->save(codecept_data_dir().''.$filename.'.xlsx');
 
         $I->amOnPage(self::$docPath.$I->getDocId());
+        $I->waitForElementVisible('//*[@id="documentOptions"]/button[@data-target="#updateFrameworkModal"]', 120);
         $I->see('Update Framework');
         $I->click('Update Framework');
         $I->waitForElementVisible('#updateFrameworkModal');


### PR DESCRIPTION
When we export a framework with a inline images to a PDF the images will actually display. 
As per the discussion, we didn't write acceptance test case for this story 
Story ID: KMS-3884
Git Issue: [493](https://github.com/opensalt/opensalt/issues/493)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/492)
<!-- Reviewable:end -->
