### PR TITLE
Fixed 'alt text was rendering with inline image in pdf' issue

### DIFF
--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -69,8 +69,8 @@ class PdfExportController extends Controller
      */
     public function render_images($string)
     {
-        $pattern = '/\!\[([^\]]*)\]\(((?:https:\/\/|\/)[^\)]+)\)/';
-        $result = preg_replace($pattern, '$1 <img src = "$2">', $string);
+        $pattern = '/\!\[([^\]]*)\]\(((?:(?:https?|):\/\/|\/)[^\)]+)\)/';
+        $result = preg_replace($pattern, '<img src = "$2">', $string);
         return $result;
     }
 }

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -69,7 +69,7 @@ class PdfExportController extends Controller
      */
     public function render_images($string)
     {
-        $pattern = '/\!\[([^\]]*)\]\(((?:(?:https?|):\/\/|\/)[^\)]+)\)/';
+        $pattern = '/\!\[([^\]]*)\]\(((?:https?:\/\/|\/)[^\)]+)\)/';
         $result = preg_replace($pattern, '<img src = "$2">', $string);
         return $result;
     }

--- a/src/Controller/PdfExportController.php
+++ b/src/Controller/PdfExportController.php
@@ -59,7 +59,7 @@ class PdfExportController extends Controller
     public function renderImages(string $string): string
     {
         $pattern = '/\!\[([^\]]*)\]\(((?:https?:\/\/|\/)[^\)]+)\)/';
-        $result = preg_replace($pattern, '<img src = "$2">', $string);
-        return $result;
+
+        return preg_replace($pattern, '<img src = "$2">', $string);
     }
 }


### PR DESCRIPTION
Fixed 'alt text was rendering with inline image in pdf' issue and also allowed http with https for image url.

Jira ID - KMS-4389
Git Issue - [505](https://github.com/opensalt/opensalt/issues/505)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/506)
<!-- Reviewable:end -->
