### PR TITLE
Rename variable that was breaking the spreadsheet update

### DIFF
--- a/src/Service/ExcelImport.php
+++ b/src/Service/ExcelImport.php
@@ -262,13 +262,13 @@ class ExcelImport
             }
 
             if ($association === null) {
-                $assoc = $this->getEntityManager()->getRepository(LsAssociation::class)->findOneBy([
+                $association = $this->getEntityManager()->getRepository(LsAssociation::class)->findOneBy([
                     'originNodeIdentifier' => $fields['originNodeIdentifier'],
                     'type' => $fields['associationType'],
                     'destinationNodeIdentifier' => $fields['destinationNodeIdentifier']
                 ]);
 
-                if (null === $assoc) {
+                if (null === $association) {
                     $association = $doc->createAssociation($fields['identifier']);
                 }
             }


### PR DESCRIPTION
Quick fix for delete parent bug, the name of the $association variable was mispelled