### PR TITLE
use correct syntax to load twig template

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -6,7 +6,7 @@ twig:
     #    thousands_separator: ','
     form_themes:
         - 'bootstrap_3_horizontal_layout.html.twig'
-        - 'TetranzSelect2EntityBundle:Form:fields.html.twig'
+        - '@TetranzSelect2Entity/Form/fields.html.twig'
     globals:
       github_client_id: "%github_client_id%"
       brand_logo_url: "%brand_logo_url%"

--- a/templates/TetranzSelect2EntityBundle:Form:fields.html.twig
+++ b/templates/TetranzSelect2EntityBundle:Form:fields.html.twig
@@ -1,1 +1,0 @@
-../vendor/tetranz/select2entity-bundle/Tetranz/Select2EntityBundle/Resources/views/Form/fields.html.twig


### PR DESCRIPTION
Change configuration to use the correct syntax to load a twig template (vs the older syntax to load a template), and remove the symlink that was added to make the older syntax work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/532)
<!-- Reviewable:end -->
