### PR TITLE
Add API endpoints for external LORs to get framework lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,18 +9,6 @@
 /tests/*.suite.yml
 /tests/_envs/*.yml
 !/tests/_envs/*.dist.yml
-/var/*
-!/var/cache
-/var/cache/*
-!var/cache/.gitkeep
-!/var/logs
-/var/logs/*
-!var/logs/.gitkeep
-!/var/sessions
-/var/sessions/*
-!var/sessions/.gitkeep
-!var/SymfonyRequirements.php
-/vendor/
 
 /public/bundles/*
 !public/bundles/.gitkeep
@@ -103,5 +91,15 @@ pw-archive/
 /.env
 /public/bundles/
 /var/
+!/var/cache
+/var/cache/*
+!/var/cache/.gitkeep
+!/var/logs
+/var/logs/*
+!/var/logs/.gitkeep
+!/var/sessions
+/var/sessions/*
+!/var/sessions/.gitkeep
+!/var/SymfonyRequirements.php
 /vendor/
 ###< symfony/framework-bundle ###

--- a/src/Controller/Api/LorSupportController.php
+++ b/src/Controller/Api/LorSupportController.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/api/lor")
+ * @Route("/api/v1/lor")
  */
 class LorSupportController extends AbstractController
 {

--- a/src/Controller/Api/LorSupportController.php
+++ b/src/Controller/Api/LorSupportController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Entity\Framework\LsDoc;
+use App\Entity\Framework\LsItem;
+use App\Repository\Framework\LsDocRepository;
+use App\Repository\Framework\LsItemRepository;
+use Psr\Log\LoggerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @Route("/api/lor")
+ */
+class LorSupportController extends AbstractController
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var LsDocRepository
+     */
+    protected $docRepository;
+
+    /**
+     * @var LsItemRepository
+     */
+    private $itemRepository;
+
+    public function __construct(LoggerInterface $logger, LsDocRepository $docRepository, LsItemRepository $itemRepository)
+    {
+        $this->logger = $logger;
+        $this->docRepository = $docRepository;
+        $this->itemRepository = $itemRepository;
+    }
+
+    /**
+     * @Route("/creators", methods={"GET"}, name="api_get_creators")
+     */
+    public function getCreators(Request $request): JsonResponse
+    {
+        // Get all creators for public documents
+        $results = $this->docRepository->findAllNonPrivate();
+
+        $creators = [];
+        $lastModified = new \DateTime('now - 10 years');
+        foreach ($results as $doc) {
+            /* @var LsDoc $doc */
+            $creator = $doc->getCreator();
+            $creators[$creator] = $creator;
+            if ($doc->getUpdatedAt() > $lastModified) {
+                $lastModified = $doc->getUpdatedAt();
+            }
+        }
+
+        $this->logger->info('API: getCreators', []);
+
+        $response = $this->generateBaseReponse($lastModified, count($creators));
+        if ($response->isNotModified($request)) {
+            return $response;
+        }
+
+        $creators = array_values($creators);
+        sort($creators);
+        $response->setData($creators);
+
+        return $response;
+    }
+
+    /**
+     * @Route("/frameworksByCreator/{creator}", methods={"GET"}, name="api_get_frameworks_by_creator")
+     */
+    public function getFrameworksByCreator(Request $request, String $creator): JsonResponse
+    {
+        $results = $this->docRepository->findNonPrivateByCreator(urldecode($creator));
+
+        $docs = [];
+        $lastModified = new \DateTime('now - 10 years');
+        foreach ($results as $doc) {
+            /* @var LsDoc $doc */
+            $docs[] = [
+                'identifier' => $doc->getIdentifier(),
+                'title' => $doc->getTitle(),
+            ];
+            if ($doc->getUpdatedAt() > $lastModified) {
+                $lastModified = $doc->getUpdatedAt();
+            }
+        }
+
+        $this->logger->info('API: getFrameworksByCreator', []);
+
+        $response = $this->generateBaseReponse($lastModified, count($docs));
+        if ($response->isNotModified($request)) {
+            return $response;
+        }
+
+        usort($docs, function ($a, $b) {
+            return strcmp($a['title'], $b['title']);
+        });
+
+        $response->setData($docs);
+
+        return $response;
+    }
+
+    /**
+     * @Route("/exactMatchIdentifiers/{identifier}", methods={"GET"}, name="api_get_exact_matches")
+     */
+    public function getMatches(Request $request, String $identifier): JsonResponse
+    {
+        $results = $this->itemRepository->findExactMatches($identifier);
+
+        $items = [];
+        $lastModified = new \DateTime('now - 10 years');
+        foreach ($results as $item) {
+            /* @var LsItem $item */
+            $items[] = $item->getIdentifier();
+            if ($item->getUpdatedAt() > $lastModified) {
+                $lastModified = $item->getUpdatedAt();
+            }
+        }
+
+        $this->logger->info('API: getMatches', []);
+
+        $response = $this->generateBaseReponse($lastModified, count($items));
+        if ($response->isNotModified($request)) {
+            return $response;
+        }
+
+        sort($items);
+
+        $response->setData([$identifier => $items]);
+
+        return $response;
+    }
+
+    /**
+     * Generate a base response
+     */
+    protected function generateBaseReponse(\DateTimeInterface $lastModified, ?int $total = null): JsonResponse
+    {
+        $response = new JsonResponse();
+
+        $response->setEtag(md5($lastModified->format('U.u')), true);
+        $response->setLastModified($lastModified);
+        $response->setMaxAge(60);
+        $response->setSharedMaxAge(60);
+        $response->setPublic();
+
+        if (null !== $total) {
+            $response->headers->set('X-Total-Count', $total);
+        }
+
+        return $response;
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -9,6 +9,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
+umask(0000);
+
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -13,8 +13,8 @@ class Framework implements Context
 {
     static public $docPath = '/cftree/doc/';
     static public $lsdocPath = '/cfdoc/';
-    static public $creatorsPath = 'api/lor/creators';
-    static public $frameworksByCreatorPath = 'api/lor/frameworksByCreator/';
+    static public $creatorsPath = 'api/v1/lor/creators';
+    static public $frameworksByCreatorPath = 'api/v1/lor/frameworksByCreator/';
 
     static public $fwTitle = '#ls_doc_create_title';
     static public $fwCreatorField = '#ls_doc_create_creator';

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -7,14 +7,14 @@ use Behat\Gherkin\Node\TableNode;
 use Codeception\Exception\Fail;
 use Codeception\Util\Locator;
 use Facebook\WebDriver\Exception\StaleElementReferenceException;
-use PhpSpec\Exception\Example\PendingException;
 use Ramsey\Uuid\Uuid;
-use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 
 class Framework implements Context
 {
     static public $docPath = '/cftree/doc/';
     static public $lsdocPath = '/cfdoc/';
+    static public $creatorsPath = 'api/lor/creators';
+    static public $frameworksByCreatorPath = 'api/lor/frameworksByCreator/';
 
     static public $fwTitle = '#ls_doc_create_title';
     static public $fwCreatorField = '#ls_doc_create_creator';
@@ -30,6 +30,7 @@ class Framework implements Context
     protected $creatorName = 'OpenSALT Testing';
     protected $frameworkData = [];
     protected $id;
+    protected $rememberedCreator;
 
     /**
      * @var \AcceptanceTester
@@ -839,6 +840,27 @@ class Framework implements Context
     }
 
     /**
+     * @When /^I create a framework with a remembered creator$/
+     */
+    public function iCreateAFrameworkRememberingTheCreator() {
+        $I = $this->I;
+
+        $I->see('Create a new Framework');
+        $I->click('Create a new Framework');
+        $I->see('Create New Framework Package');
+
+        /** @var \Faker\Generator $faker */
+        $faker = \Faker\Factory::create();
+        $this->rememberedCreator = $faker->company;
+        $oldCreator = $this->creatorName;
+        $this->creatorName = $this->rememberedCreator;
+
+        $this->iCreateAFramework();
+
+        $this->creatorName = $oldCreator;
+    }
+
+    /**
      * @Given /^I should see the framework$/
      * @Given /^I should see the framework data$/
      */
@@ -1231,4 +1253,43 @@ class Framework implements Context
         $I->dontSee('A.B.D ghi');
     }
 
+    /**
+     * @When /^I fetch a list of creators$/
+     */
+    public function iFetchAListOfCreators()
+    {
+        $I = $this->I;
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->sendGET(static::$creatorsPath);
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+    }
+
+    /**
+     * @Then /^the remembered creator will be in the list$/
+     */
+    public function theRememberedCreatorWillBeInTheList()
+    {
+        $this->I->seeResponseContainsJson([$this->rememberedCreator]);
+    }
+
+    /**
+     * @When /^I fetch a list of frameworks by the remembered creator$/
+     */
+    public function iFetchAListOfFrameworksByTheRememberedCreator()
+    {
+        $I = $this->I;
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->sendGET(static::$frameworksByCreatorPath.rawurlencode($this->rememberedCreator));
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+    }
+
+    /**
+     * @Then /^the created framework will be in the list$/
+     */
+    public function theCreatedFrameworkWillBeInTheList()
+    {
+        $this->I->seeResponseContainsJson(['title' => $this->rememberedFramework]);
+    }
 }

--- a/tests/_support/Page/Item.php
+++ b/tests/_support/Page/Item.php
@@ -11,7 +11,7 @@ use Facebook\WebDriver\Exception\StaleElementReferenceException;
 class Item implements Context
 {
     static public $itemPath = '/cftree/item/';
-    static public $exactMatchesPath = 'api/lor/exactMatchIdentifiers/';
+    static public $exactMatchesPath = 'api/v1/lor/exactMatchIdentifiers/';
 
     protected $rememberedItem;
     protected $itemData = [];

--- a/tests/_support/Page/Item.php
+++ b/tests/_support/Page/Item.php
@@ -11,6 +11,7 @@ use Facebook\WebDriver\Exception\StaleElementReferenceException;
 class Item implements Context
 {
     static public $itemPath = '/cftree/item/';
+    static public $exactMatchesPath = 'api/lor/exactMatchIdentifiers/';
 
     protected $rememberedItem;
     protected $itemData = [];
@@ -94,8 +95,9 @@ class Item implements Context
         $I = $this->I;
         $I->waitForText('Add New Child Item', 30);
         $I->see('Add New Child Item');
+        $I->wait(1);
         $I->click('Add New Child Item');
-        $I->waitForElementVisible('#ls_item');
+        $I->waitForElementVisible('#ls_item', 30);
         $I->waitForElementVisible('#ls_item_listEnumInSource');
 
         $I->executeJS("$('#ls_item_fullStatement').nextAll('.CodeMirror')[0].CodeMirror.getDoc().setValue('{$fullStatement}')");
@@ -121,6 +123,19 @@ class Item implements Context
         }
 
         $I->remember($requestedItem, $item);
+
+        $frameworkUrl = $I->grabFromCurrentUrl('/(.*)/');
+
+        $I->click("//section[@id='tree1Section']//span[@class='item-humanCodingScheme'][text()='{$item}']");
+        $itemId = $I->grabFromCurrentUrl('#/(\d+)$#');
+        $I->remember($requestedItem.'-id', $itemId);
+
+        $uri = $I->grabAttributeFrom('li.lsItemDetailsExtras a', 'href');
+        preg_match('#/([a-f0-9-]{32,36})$#', $uri, $matches);
+        $key = $matches[1];
+        $I->remember($requestedItem.'-identifier', $key);
+
+        $I->amOnPage($frameworkUrl);
     }
 
     /**
@@ -252,6 +267,7 @@ class Item implements Context
 
     /**
      * @Given /^I add a Association$/
+     * @Given /^I add an Association$/
      */
     public function iAddAAssociation()
     {
@@ -265,6 +281,29 @@ class Item implements Context
         $I->waitForElementVisible('(//div[@id="viewmode_tree2"]/ul/li/ul/li/span)[1]');
         $I->dragAndDrop('(//div[@id="viewmode_tree2"]/ul/li/ul/li/span)[1]', '(//div[@id="viewmode_tree1"]/ul/li/ul/li/span)[1]');
         $I->waitForElementVisible('#lsAssociationSwitchDirection');
+        $I->click('Associate');
+    }
+
+    /**
+     * @When /^I add a "([^"]*)" association from "([^"]*)" to "([^"]*)"$/
+     * @When /^I add an "([^"]*)" association from "([^"]*)" to "([^"]*)"$/
+     */
+    public function iAddAnAssociationFromTo($type, $from, $to)
+    {
+        $I = $this->I;
+
+        $rememberedFrom = $I->getRememberedString($from);
+        $rememberedTo = $I->getRememberedString($to);
+
+        $this->iAmOnAnItemPage();
+        $I->waitForElementVisible('#rightSideCopyItemsBtn');
+        $I->click('Create Association');
+        $I->see('Select a Competency Framework Document to view on the right side.');
+        $I->selectOption('#ls_doc_list_lsDoc_right', array('text' => $I->getLastFrameworkTitle() . ' (• DOCUMENT BEING EDITED •)'));
+        $I->waitForElementVisible('(//div[@id="viewmode_tree2"]/ul/li/ul/li/span)[1]');
+        $I->dragAndDrop("(//div[@id='viewmode_tree2']/ul/li/ul/li/span//span[text()='{$rememberedFrom}']/../..)[1]", "(//div[@id='viewmode_tree1']/ul/li/ul/li/span//span[text()='{$rememberedTo}']/../..)[1]");
+        $I->waitForElementVisible('#lsAssociationSwitchDirection');
+        $I->selectOption('#associationFormType', array('text' => $type));
         $I->click('Associate');
     }
 
@@ -417,6 +456,26 @@ class Item implements Context
         $I->see('A.B abc');
         $I->see('A.B.C def');
         $I->see('A.B.D ghi');
+    }
+
+    /**
+     * @When /^I get the exact matches of "([^"]*)"$/
+     */
+    public function iGetTheExactMatchesOf($itemName)
+    {
+        $I = $this->I;
+        $I->haveHttpHeader('Accept', 'application/json');
+        $I->sendGET(static::$exactMatchesPath.$I->getRememberedString($itemName.'-identifier'));
+        $I->seeResponseCodeIs(200);
+        $I->seeResponseIsJson();
+    }
+
+    /**
+     * @When /^I see the identifier for "([^"]*)" in the list of exact matches$/
+     */
+    public function iSeeInTheListOfExactMatches($itemName)
+    {
+        $this->I->seeResponseContainsJson([$this->I->getRememberedString($itemName.'-identifier')]);
     }
 
     protected function waitAndAcceptPopup($tries = 30)

--- a/tests/acceptance.suite.dist.yml
+++ b/tests/acceptance.suite.dist.yml
@@ -9,6 +9,9 @@ modules:
         - Doctrine2:
             depends: Symfony2Module
             cleanup: false
+        - REST:
+            depends: PhpBrowser
+            url: 'http://nginx/'
         - WebDriver:
             url: 'http://nginx/'
             browser: firefox

--- a/tests/acceptance/features/api/organization_editor/fetch_by_creator.feature
+++ b/tests/acceptance/features/api/organization_editor/fetch_by_creator.feature
@@ -1,0 +1,14 @@
+Feature: Fetch a list of frameworks from a creator from the API
+  In order to display a list of frameworks from a creator
+  As another system
+  I can fetch a list of frameworks by creator
+
+  @api @0606-1251
+  Scenario: 0606-1251
+    Given I log in as a user with role "Editor"
+    And I create a framework with a remembered creator
+
+    When I fetch a list of frameworks by the remembered creator
+    Then the created framework will be in the list
+
+    Then I delete the framework

--- a/tests/acceptance/features/api/organization_editor/fetch_creators.feature
+++ b/tests/acceptance/features/api/organization_editor/fetch_creators.feature
@@ -1,0 +1,14 @@
+Feature: Fetch creators from API
+  In order to display a list of creators
+  As another system
+  I can fetch a list of creators
+
+  @api @0606-1250
+  Scenario: 0606-1250
+    Given I log in as a user with role "Editor"
+    And I create a framework with a remembered creator
+
+    When I fetch a list of creators
+    Then the remembered creator will be in the list
+
+    Then I delete the framework

--- a/tests/acceptance/features/api/organization_editor/fetch_matches.feature
+++ b/tests/acceptance/features/api/organization_editor/fetch_matches.feature
@@ -1,0 +1,22 @@
+Feature: Fetch matches from API
+  In order to tag a resource
+  As another system
+  I can fetch a list of all exact matches of an identifier
+
+  @api @0606-1252
+  Scenario: 0606-1252
+    Given I log in as a user with role "Editor"
+    And I create a framework with a remembered creator
+
+    When I add the item "first"
+    And I add the item "second"
+    And I add the item "third"
+
+    And I add an "Exact Match Of" association from "second" to "first"
+    And I add an "Exact Match Of" association from "third" to "first"
+
+    And I get the exact matches of "third"
+    Then I see the identifier for "second" in the list of exact matches
+
+
+    Then I delete the framework


### PR DESCRIPTION
Add endpoints to allow an external LOR to be able to get lists of frameworks by creator without having to fetch and parse the entire CFDocuments list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/537)
<!-- Reviewable:end -->
