### PR TITLE
Change label for username/email on signup form

### DIFF
--- a/src/Form/Type/SignupType.php
+++ b/src/Form/Type/SignupType.php
@@ -32,7 +32,7 @@ class SignupType extends AbstractType
         $builder
             ->add('username', TextType::class, [
                 'attr' => ['class' => 'form-control'],
-                'label' => 'Email Address',
+                'label' => 'Username (Email address)',
             ])
             ->add('plainPassword', RepeatedType::class, [
                 'type' => PasswordType::class,

--- a/templates/user/signup/signup.html.twig
+++ b/templates/user/signup/signup.html.twig
@@ -1,5 +1,9 @@
 {% extends 'base.html.twig' %}
 
+{% form_theme form _self %}
+{% block form_label_class -%}col-sm-3{%- endblock form_label_class %}
+{% block form_group_class -%}col-sm-9{%- endblock form_group_class %}
+
 {% block body %}
     <div class="container">
     <h1>Create new account</h1>
@@ -11,8 +15,8 @@
 
         {{ form_row(form.org) }}
         <div class="form-group js-add-org-message">
-            <div class="col-sm-2"></div>
-            <div class="col-sm-10">
+            <div class="col-sm-3"></div>
+            <div class="col-sm-9">
                 <i>If your organization is not in the list, select Other to add it.</i>
             </div>
         </div>

--- a/tests/acceptance/features/user/public_user/create_account_validations.feature
+++ b/tests/acceptance/features/user/public_user/create_account_validations.feature
@@ -7,7 +7,7 @@ Feature: Create new account validations
         And I follow "Sign up"
 
         Then I should see "Create new account"
-        Then I fill in the "Email Address" with "username"
+        Then I fill in the "Username (Email address)" with "username"
         Then I fill in the "Password" with "Password123!"
         Then I fill in the "Confirm Password" with "Password123!"
         Then I click "Submit"
@@ -20,7 +20,7 @@ Feature: Create new account validations
         And I follow "Sign up"
 
         Then I should see "Create new account"
-        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Username (Email address)" with "user@opensalt.com"
         Then I fill in the "Password" with "Password123!"
         Then I fill in the "Confirm Password" with "password"
         Then I click "Submit"
@@ -33,7 +33,7 @@ Feature: Create new account validations
         And I follow "Sign up"
 
         Then I should see "Create new account"
-        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Username (Email address)" with "user@opensalt.com"
         Then I fill in the "Password" with "password"
         Then I fill in the "Confirm Password" with "password"
         Then I click "Submit"

--- a/tests/acceptance/features/user/public_user/password_length_eight_char.feature
+++ b/tests/acceptance/features/user/public_user/password_length_eight_char.feature
@@ -7,7 +7,7 @@ Feature: Create new user account password should be 8 characters long
         And I follow "Sign up"
 
         Then I should see "Create new account"
-        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Username (Email address)" with "user@opensalt.com"
         Then I fill in the "Password" with "Password123!"
         Then I fill in the "Confirm Password" with "password"
         Then I click "Submit"
@@ -20,7 +20,7 @@ Feature: Create new user account password should be 8 characters long
         And I follow "Sign up"
 
         Then I should see "Create new account"
-        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Username (Email address)" with "user@opensalt.com"
         Then I fill in the "Password" with "password"
         Then I fill in the "Confirm Password" with "password"
         Then I click "Submit"
@@ -33,7 +33,7 @@ Feature: Create new user account password should be 8 characters long
         And I follow "Sign up"
 
         Then I should see "Create new account"
-        Then I fill in the "Email Address" with "user@opensalt.com"
+        Then I fill in the "Username (Email address)" with "user@opensalt.com"
         Then I fill in the "Password" with "pass@1"
         Then I fill in the "Confirm Password" with "pass@1"
         Then I click "Submit"


### PR DESCRIPTION
Change the label for the username on the signup form to indicate that it is the username and must be an email address.

resolves #480

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/551)
<!-- Reviewable:end -->
