### PR TITLE
ci: do not push images for PRs from other repos

### DIFF
--- a/ci/travis/send_errors.sh
+++ b/ci/travis/send_errors.sh
@@ -7,6 +7,10 @@ docker-compose -f docker/docker-compose.yml logs phpfpm > tests/_output/phpfpm.t
 cat tests/_output/phpfpm.txt
 echo "--------------------------------------------------------------------"
 
+if [ "$DOCKER_USER" = "" -o "$DOCKER_PASS" = "" ]; then
+    exit
+fi
+
 cp docker/errors/Dockerfile tests/_output/
 cd tests/_output
 docker build . -t opensalt/app:errors-${TRAVIS_BUILD_NUMBER}


### PR DESCRIPTION
If a PR is from another repository then travis will not have access to
encrypted variables, so do not try to use them to push to docker hub.

resolves #585

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/586)
<!-- Reviewable:end -->
