### PR TITLE
Passing the docId instead of the itemId when uploading an attachment

### DIFF
--- a/assets/js/cftree/view-edit.js
+++ b/assets/js/cftree/view-edit.js
@@ -138,7 +138,7 @@ apx.edit.prepareItemEditModal = function() {
 
                 statementMde = render.mde($('#ls_item_fullStatement')[0]);
                 notesMde = render.mde($('#ls_item_notes')[0]);
-                var path = '/cfitem/'+apx.mainDoc.currentItem.id+'/upload_attachment';
+                var path = '/cfitem/'+apx.mainDoc.doc.id+'/upload_attachment';
 
                 inlineAttachment.editors.codemirror4.attach(
                     statementMde.codemirror, { uploadUrl: path }
@@ -230,7 +230,7 @@ apx.edit.prepareItemEditModal = function() {
             });
             statementMde = render.mde($('#ls_item_fullStatement')[0]);
             notesMde = render.mde($('#ls_item_notes')[0]);
-            var path = '/cfitem/'+apx.mainDoc.currentItem.id+'/upload_attachment';
+            var path = '/cfitem/'+apx.mainDoc.doc.id+'/upload_attachment';
 
             inlineAttachment.editors.codemirror4.attach(
                 statementMde.codemirror, { uploadUrl: path }
@@ -281,7 +281,7 @@ apx.edit.prepareAddNewChildModal = function() {
                 });
                 statementMde = render.mde($('#ls_item_fullStatement')[0]);
                 notesMde = render.mde($('#ls_item_notes')[0]);
-                var path = '/cfitem/'+apx.mainDoc.currentItem.id+'/upload_attachment';
+                var path = '/cfitem/'+apx.mainDoc.doc.id+'/upload_attachment';
 
                 inlineAttachment.editors.codemirror4.attach(
                     statementMde.codemirror, { uploadUrl: path }
@@ -332,7 +332,7 @@ apx.edit.prepareAddNewChildModal = function() {
             });
             statementMde = render.mde($('#ls_item_fullStatement')[0]);
             notesMde = render.mde($('#ls_item_notes')[0]);
-            var path = '/cfitem/'+apx.mainDoc.currentItem.id+'/upload_attachment';
+            var path = '/cfitem/'+apx.mainDoc.doc.id+'/upload_attachment';
 
             inlineAttachment.editors.codemirror4.attach(
                 statementMde.codemirror, { uploadUrl: path }

--- a/src/Controller/Framework/LsItemController.php
+++ b/src/Controller/Framework/LsItemController.php
@@ -396,7 +396,7 @@ class LsItemController extends AbstractController
      *
      * @Route("/{id}/upload_attachment", methods={"POST"}, name="lsitem_upload_attachment")
      * @Template()
-     * @Security("is_granted('edit', lsItem)")
+     * @Security("is_granted('add-standard-to', doc)")
      *
      * @param Request $request
      * @param LsItem $lsItem
@@ -404,7 +404,7 @@ class LsItemController extends AbstractController
      *
      * @return Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function uploadAttachmentAction(Request $request, LsItem $lsItem, BucketService $bucket)
+    public function uploadAttachmentAction(Request $request, LsDoc $doc, BucketService $bucket)
     {
         if (!empty($this->bucketProvider)) {
             $file = $request->files->get('file');


### PR DESCRIPTION
This is a change to be able to upload an attachment when creating a new item

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/591)
<!-- Reviewable:end -->
