### PR TITLE
Redirect to login page when session times out

### DIFF
--- a/src/Security/Session/SessionIdleHandler.php
+++ b/src/Security/Session/SessionIdleHandler.php
@@ -2,27 +2,24 @@
 
 namespace App\Security\Session;
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class SessionIdleHandler
 {
-    protected $session;
     protected $securityToken;
     protected $securityContext;
-    protected $router;
     protected $maxIdleTime;
 
-    public function __construct(SessionInterface $session, AuthorizationCheckerInterface $securityContext, TokenStorageInterface $securityToken, RouterInterface $router, $sessionMaxIdleTime = 0)
+    public function __construct(AuthorizationCheckerInterface $securityContext, TokenStorageInterface $securityToken, $sessionMaxIdleTime = 0)
     {
-        $this->session = $session;
-        $this->securityToken = $securityToken;
-        $this->router = $router;
-        $this->maxIdleTime = $sessionMaxIdleTime;
         $this->securityContext = $securityContext;
+        $this->securityToken = $securityToken;
+        $this->maxIdleTime = $sessionMaxIdleTime;
     }
 
     public function onKernelRequest(GetResponseEvent $event): void
@@ -35,17 +32,42 @@ class SessionIdleHandler
             return;
         }
 
-        $isFullyAuthenticated = $this->securityContext->isGranted('IS_AUTHENTICATED_FULLY');
-        if (0 < $this->maxIdleTime && true === $isFullyAuthenticated) {
-            $this->session->start();
-            $lapse = time() - $this->session->getMetadataBag()->getLastUsed();
-
-            if ($lapse > $this->maxIdleTime) {
-                $this->securityToken->setToken(null);
-                $this->session->getFlashBag()->set('warning', 'You have been logged out due to inactivity.');
-
-                //$event->setResponse(new RedirectResponse($this->router->generate('login')));
-            }
+        if (!$this->securityContext->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return;
         }
+
+        if (0 >= $this->maxIdleTime) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $session = $request->getSession();
+
+        if (null === $session) {
+            return;
+        }
+
+        $session->start();
+        $lapse = time() - $session->getMetadataBag()->getLastUsed();
+
+        if ($lapse < $this->maxIdleTime) {
+            return;
+        }
+
+        try {
+            $anonymousToken = new AnonymousToken(base64_encode(random_bytes(6)), 'anon.', []);
+        } catch (\Exception $e) {
+            // An exception can be thrown from random_bytes() if there is not enough entropy
+            $anonymousToken = new AnonymousToken(substr(sha1(mt_rand()), 0, 8), 'anon.', []);
+        }
+        $this->securityToken->setToken($anonymousToken);
+
+        $msg = 'You have been logged out due to inactivity.';
+        $session->invalidate();
+        if ($session instanceof Session) {
+            $session->getFlashBag()->set('warning', $msg);
+        }
+
+        throw new AccessDeniedException($msg);
     }
 }


### PR DESCRIPTION
When a logged-in user is on a protected page such as `/system_log` and
their session times out then redirect the user to the login page when
the user reloads the page.

fixes #627

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/628)
<!-- Reviewable:end -->
