### PR TITLE
moved CASE identifier to be firstabove the line

### DIFF
--- a/assets/js/cftree/view-documentclass.js
+++ b/assets/js/cftree/view-documentclass.js
@@ -1475,6 +1475,8 @@ function ApxDocument(initializer) {
             let html = "";
             let key, attributes, val;
             for (key in attributes = {
+                'uri': 'CASE URI',
+                'identifier': 'CASE Identifier',
                 'fstmt': 'Full Statement',
                 'ck': 'Concept Keywords',
                 'el': 'Education Level',
@@ -1501,8 +1503,6 @@ function ApxDocument(initializer) {
             }
 
             for (key in attributes = {
-                'uri': 'CASE URI',
-                'identifier': 'CASE Identifier',
                 'le': 'List Enumeration in Source',
                 'cku': 'Concept Keywords URI',
                 'lang': 'Language',

--- a/assets/js/cftree/view-documentclass.js
+++ b/assets/js/cftree/view-documentclass.js
@@ -1495,7 +1495,9 @@ function ApxDocument(initializer) {
                         // TODO: deal with ck, el, itp
                         html += '<li class="list-group-item">'
                             + '<strong>' + attributes[key] + ':</strong> '
-                            + render.escaped(val)
+                            + '<span class="item-' + key + '">'
+                              + render.escaped(val)
+                              + '</span>'
                             + '</li>'
                         ;
                     }

--- a/assets/js/cftree/view-documentclass.js
+++ b/assets/js/cftree/view-documentclass.js
@@ -1357,8 +1357,8 @@ function ApxDocument(initializer) {
             let key, attributes, val;
             for (key in attributes = {
                 'officialSourceURL': 'Official URL',
-                'uri': 'CASE URI',
-                'identifier': 'CASE Identifier',
+                'uri': 'Framework URI',
+                'identifier': 'Identifier',
                 'creator': 'Creator',
                 'description': 'Description',
                 'subjects': 'Subject',
@@ -1475,8 +1475,8 @@ function ApxDocument(initializer) {
             let html = "";
             let key, attributes, val;
             for (key in attributes = {
-                'uri': 'CASE URI',
-                'identifier': 'CASE Identifier',
+                'uri': 'URI',
+                'identifier': 'Identifier',
                 'fstmt': 'Full Statement',
                 'ck': 'Concept Keywords',
                 'el': 'Education Level',

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -871,7 +871,7 @@ class Framework implements Context
 
         $I->see('Official URL:');
         $I->see($this->frameworkData['officialUri']);
-        $I->see('CASE URI:');
+        $I->see('URI:');
         $I->see('Creator:');
         $I->see($this->frameworkData['creator']);
         $I->see('Publisher:');

--- a/tests/_support/Page/Item.php
+++ b/tests/_support/Page/Item.php
@@ -130,9 +130,7 @@ class Item implements Context
         $itemId = $I->grabFromCurrentUrl('#/(\d+)$#');
         $I->remember($requestedItem.'-id', $itemId);
 
-        $uri = $I->grabAttributeFrom('li.lsItemDetailsExtras a', 'href');
-        preg_match('#/([a-f0-9-]{32,36})$#', $uri, $matches);
-        $key = $matches[1];
+        $key = $I->grabTextFrom('div.lsItemDetails li.list-group-item .item-identifier');
         $I->remember($requestedItem.'-identifier', $key);
 
         $I->amOnPage($frameworkUrl);


### PR DESCRIPTION
patch to fully address #644 . 

Case URI And CASE identifier are now always the first two fields one sees in CfDoc or CfItem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/648)
<!-- Reviewable:end -->
