### PR TITLE
copy framework in the correct direction

### DIFF
--- a/src/Controller/Framework/CopyController.php
+++ b/src/Controller/Framework/CopyController.php
@@ -23,20 +23,13 @@ class CopyController extends AbstractController
     /**
      * @Route("/framework/{id}", name="copy_framework_content", methods={"POST"})
      * @Security("is_granted('edit', lsDoc)")
-     *
-     * @param Request $request
-     * @param LsDoc $lsDoc
-     * @param LsDoc $toLsDoc
-     *
-     * @return array
      */
-    public function frameworkAction(Request $request, LsDoc $lsDoc)
+    public function frameworkAction(Request $request, LsDoc $lsDoc): JsonResponse
     {
         $eManager = $this->getDoctrine()->getManager();
 
         $type = $request->request->get('type');
-        $frameworkToCopy = $request->request->get('frameworkToCopy');
-
+        $frameworkToCopy = $request->request->get('copyToFramework');
         $toLsDoc = $eManager->getRepository(LsDoc::class)->find($frameworkToCopy);
 
         $command = new CopyFrameworkCommand($lsDoc, $toLsDoc, $type);
@@ -46,8 +39,7 @@ class CopyController extends AbstractController
             'message' => 'Framework successful copied!',
             'docDestinationId' => $frameworkToCopy,
             'frameworkToCopy' => $toLsDoc->getTitle(),
-            'type' => $type
+            'type' => $type,
         ]);
     }
-
 }

--- a/src/Handler/Framework/CopyFrameworkHandler.php
+++ b/src/Handler/Framework/CopyFrameworkHandler.php
@@ -4,6 +4,7 @@ namespace App\Handler\Framework;
 
 use App\Command\Framework\CopyFrameworkCommand;
 use App\Event\CommandEvent;
+use App\Event\NotificationEvent;
 use App\Handler\BaseDoctrineHandler;
 use App\Entity\Framework\LsDoc;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -23,5 +24,10 @@ class CopyFrameworkHandler extends BaseDoctrineHandler
         $this->em->getRepository(LsDoc::class)
             ->copyDocumentContentToDoc($fromDoc, $toDoc, 'copyAndAssociate' === $copyType);
 
+        $command->setNotificationEvent(new NotificationEvent(
+            'D10',
+            sprintf('Framework "%s" copied to "%s"', $fromDoc->getTitle(), $toDoc->getTitle()),
+            $toDoc
+        ));
     }
 }

--- a/src/Repository/Framework/LsDocRepository.php
+++ b/src/Repository/Framework/LsDocRepository.php
@@ -15,6 +15,7 @@ use App\Util\Compare;
 /**
  * LsDocRepository
  *
+ * @method LsDoc|null find(int $id)
  * @method LsDoc[]|array findByCreator(String $creator)
  * @method LsDoc|null findOneByIdentifier(string $identifier)
  */
@@ -350,11 +351,7 @@ xENDx;
         $progressCallback('Done');
     }
 
-    /**
-     * @param LsDoc $fromDoc
-     * @param LsDoc $toDoc
-     */
-    public function copyDocumentContentToDoc(LsDoc $fromDoc, LsDoc $toDoc, $exactMatchAssocs = false)
+    public function copyDocumentContentToDoc(LsDoc $fromDoc, LsDoc $toDoc, $exactMatchAssocs = false): void
     {
         foreach ($fromDoc->getTopLsItems() as $oldItem) {
             $newItem = $oldItem->copyToLsDoc($toDoc, null, $exactMatchAssocs);
@@ -365,7 +362,7 @@ xENDx;
     public function makeDerivative(LsDoc $oldLsDoc, $newLsDoc = null): LsDoc
     {
         $em = $this->getEntityManager();
-        if(null === $newLsDoc) {
+        if (null === $newLsDoc) {
             $newLsDoc = new LsDoc();
             $newLsDoc->setTitle($oldLsDoc->getTitle().' - Derivated');
             $newLsDoc->setCreator($oldLsDoc->getCreator());
@@ -379,7 +376,7 @@ xENDx;
             $newLsDoc->setLicence($oldLsDoc->getLicence());
         }
 
-        foreach($oldLsDoc->getAssociationGroupings() as $assocGroup) {
+        foreach ($oldLsDoc->getAssociationGroupings() as $assocGroup) {
             $assocGroup->duplicateToLsDoc($newLsDoc);
         }
 

--- a/templates/framework/doc_tree/view.html.twig
+++ b/templates/framework/doc_tree/view.html.twig
@@ -755,6 +755,7 @@
             apx.path.doc_tree_multi_changes = '{{ path('multi_tree_info_json', {'id':'ID'}) }}';
             apx.path.doc_revisions = '{{ path('doc_revisions_json', {'id':'ID'}) }}';
             apx.path.doc_revisions_export = '{{ path('doc_revisions_csv', {'id': 'ID'}) }}';
+            apx.path.doc_copy = '{{ path('copy_framework_content', {'id': 'ID'}) }}';
 
             apx.path.doctree_cfpackage_export = '{{ path('doctree_cfpackage_export', {'id':'ID'}) }}';
             apx.path.doctree_retrieve_document = '{{ path('doctree_retrieve_document', {'id':'ID'}) }}';


### PR DESCRIPTION
- clicking "Copy and associate with original" no longer resets copy
  direction
- add changelog entry when a framework is copied

fixes #646

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/670)
<!-- Reviewable:end -->
