### PR TITLE
Fix/spreadsheet importer

### DIFF
--- a/assets/js/lsdoc/index.js
+++ b/assets/js/lsdoc/index.js
@@ -410,7 +410,7 @@ var SaltLocal = (function () {
                     },
                     error: function () {
                         $('.tab-content').removeClass('hidden');
-                        $('.case-error-msg').html('Error while importing the file');
+                        $('.case-error-msg').html("We're sorry, we cannot load this document. Please ensure this document is not already on the server, or see the Spreadsheet loading guide at docs.opensalt.org");
                         $('.case-error-msg').removeClass('hidden');
                         $('.file-loading').addClass('hidden');
                     }

--- a/src/Service/ExcelImport.php
+++ b/src/Service/ExcelImport.php
@@ -83,7 +83,7 @@ final class ExcelImport
                 $seq = null;
             }
 
-            if (array_key_exists($parentLevel, $itemSmartLevels)) {
+            if (in_array($parentLevel, $itemSmartLevels)) {
                 $smartLevels[$parentLevel]->addChild($item, null, $seq);
                 $children[$item->getIdentifier()] = $doc->getIdentifier();
             } else {

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -1448,6 +1448,7 @@ class Framework implements Context
         $I = $this->I;
 
         $I->see($this->rememberedFramework);
+        $I->executeJS("$('#tree1Section div.treeDiv').fancytree('getTree').visit(function(n){n.setExpanded(true);});");
 
         $I->see('S Statement 1');
         $I->see('S.1 Statement 2');


### PR DESCRIPTION
The `ExcelImport` service was comparing the `$smartLevel` against the `$itemSmartLevel` with the wrong function ( `array_key_exists` ) it won't work since the `$smartLevel` has the actual level and the `$itemSmartLevel` keys have the item's identifier, that's why it wasn't creating the parent items. I'm changing `array_key_exists` for `in_array` to compare the `$smartLevel` against the `$itemSmartLevels` values.

Also updated the error message when importing a framework and the process fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/679)
<!-- Reviewable:end -->
