### PR TITLE
fix: process education level string during import

### DIFF
--- a/src/Service/CaseImport.php
+++ b/src/Service/CaseImport.php
@@ -6,6 +6,7 @@ use App\Entity\Framework\LsDefItemType;
 use App\Entity\Framework\LsDoc;
 use App\Entity\Framework\LsItem;
 use App\Entity\Framework\LsAssociation;
+use App\Util\EducationLevelSet;
 use Doctrine\ORM\EntityManagerInterface;
 
 class CaseImport
@@ -25,13 +26,6 @@ class CaseImport
         return $this->entityManager;
     }
 
-    /**
-     * Import a CASE file
-     *
-     * @param \stdClass $fileContent JSON content
-     *
-     * @return LsDoc
-     */
     public function importCaseFile(\stdClass $fileContent): LsDoc
     {
         set_time_limit(180); // increase time limit for large files
@@ -115,59 +109,8 @@ class CaseImport
                     continue;
                 }
 
-                $grades = [];
-                foreach ($importedGrades as $grade) {
-                    switch ($grade) {
-                        case '0':
-                        case '00':
-                        case 'K':
-                            $grades[] = 'KG';
-                            break;
-                        case 'HS':
-                            $grades[] = '09';
-                            $grades[] = '10';
-                            $grades[] = '11';
-                            $grades[] = '12';
-                            break;
-                        default:
-                            if (is_numeric($grade)) {
-                                if ($grade < 10) {
-                                    $grades[] = '0'.((int) $grade);
-                                } elseif ($grade < 14) {
-                                    $grades[] = $grade;
-                                } else {
-                                    $grades[] = 'OT';
-                                }
-                            } else {
-                                if (in_array(
-                                    $grade,
-                                    [
-                                        'IT',
-                                        'PR',
-                                        'PK',
-                                        'TK',
-                                        'KG',
-                                        'AS',
-                                        'BA',
-                                        'PB',
-                                        'MD',
-                                        'PM',
-                                        'DO',
-                                        'PD',
-                                        'AE',
-                                        'PT',
-                                        'OT',
-                                    ],
-                                    true
-                                )) {
-                                    $grades[] = $grade;
-                                } else {
-                                    $grades[] = 'OT';
-                                }
-                            }
-                    }
-                }
-                $lsItem->setEducationalAlignment(implode(',', array_unique($grades)));
+                $grades = EducationLevelSet::fromArray($importedGrades);
+                $lsItem->setEducationalAlignment($grades->toString());
             }
             if (property_exists($cfItem, 'language')) {
                 $lsItem->setLanguage($cfItem->language);
@@ -201,7 +144,7 @@ class CaseImport
             }
             if (property_exists($cfAssociation, 'associationType')) {
                 $associationType = ucfirst(preg_replace('/([A-Z])/', ' $1', $cfAssociation->associationType));
-                if (in_array($associationType, LsAssociation::allTypes())) {
+                if (in_array($associationType, LsAssociation::allTypes(), true)) {
                     $lsAssociation->setType($associationType);
                 }
             }

--- a/src/Service/ExcelImport.php
+++ b/src/Service/ExcelImport.php
@@ -10,6 +10,7 @@ use App\Entity\Framework\LsDefLicence;
 use App\Entity\Framework\LsDoc;
 use App\Entity\Framework\LsItem;
 use App\Entity\Framework\AdditionalField;
+use App\Util\EducationLevelSet;
 use Doctrine\ORM\EntityManagerInterface;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Ramsey\Uuid\Uuid;
@@ -211,7 +212,7 @@ final class ExcelImport
             $item->setConceptKeywords($this->getCellValueOrNull($sheet, 7, $row));
             $item->setNotes($this->getCellValueOrNull($sheet, 8, $row));
             $item->setLanguage($this->getCellValueOrNull($sheet, 9, $row));
-            $item->setEducationalAlignment($this->getCellValueOrNull($sheet, 10, $row));
+            $this->setEducationalAlignment($item, $this->getCellValueOrNull($sheet, 10, $row));
 
             $itemTypeTitle = $this->getCellValueOrNull($sheet, 11, $row);
             $itemType = $this->findItemType($itemTypeTitle);
@@ -393,5 +394,10 @@ final class ExcelImport
             }
             ++$column;
         }
+    }
+
+    private function setEducationalAlignment(LsItem $item, ?string $passedGradeString): void
+    {
+        $item->setEducationalAlignment(EducationLevelSet::fromString($passedGradeString)->toString());
     }
 }

--- a/src/Util/EducationLevelSet.php
+++ b/src/Util/EducationLevelSet.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Util;
+
+class EducationLevelSet
+{
+    /**
+     * @var array
+     */
+    private $grades;
+
+    public function __construct(array $passedGrades)
+    {
+        $gradeSets = [[]]; // initialize the array with an empty array inside it
+        foreach ($passedGrades as $grade) {
+            if (empty($grade) || !is_string($grade)) {
+                continue;
+            }
+            $gradeSets[] = self::convertGradeString($grade);
+        }
+
+        $this->grades = array_unique(array_merge(...$gradeSets));
+    }
+
+    public static function fromString(?string $passedGradeString): self
+    {
+        $passedGrades = str_replace(' ', '', $passedGradeString);
+        $passedGrades = explode(',', $passedGrades);
+
+        return new self($passedGrades);
+    }
+
+    public static function fromArray(array $passedGradeArray): self
+    {
+        return new self($passedGradeArray);
+    }
+
+    public function toString(): ?string
+    {
+        if (0 === count($this->grades)) {
+            return null;
+        }
+
+        return implode(',', $this->grades);
+    }
+
+    public function toArray(): array
+    {
+        return $this->grades;
+    }
+
+    private static function normalizeGrade(string $grade): string
+    {
+        if (is_numeric($grade)) {
+            return self::normalizeNumericGrade($grade);
+        }
+
+        return self::normalizeStringGrade($grade);
+    }
+
+    private static function convertGradeString(string $gradeString): array
+    {
+        if ('OT' === $gradeString) {
+            return [$gradeString];
+        }
+
+        $grade = self::normalizeGrade($gradeString);
+        if ('OT' !== $grade) {
+            return [$grade];
+        }
+
+        $grades = self::translateGradeString($gradeString);
+        if (0 < count($grades)) {
+            return $grades;
+        }
+
+        if (false !== strpos($gradeString, '-')) {
+            [$lo, $hi] = explode('-', $gradeString, 2);
+
+            $lo = self::normalizeGrade($lo);
+            if ('KG' === $lo) {
+                $lo = '0';
+            }
+
+            $hi = self::normalizeGrade($hi);
+            if ('KG' === $hi) {
+                $hi = '0';
+            }
+
+            if (!is_numeric($lo) || !is_numeric($hi) || $hi < $lo) {
+                return ['OT'];
+            }
+
+            return array_map(function ($x) {
+                return self::normalizeGrade($x);
+            }, range($lo, $hi));
+        }
+
+        return ['OT'];
+    }
+
+    private static function translateGradeString(string $gradeString): array
+    {
+        if ('HS' === $gradeString) {
+            return [
+                '09',
+                '10',
+                '11',
+                '12',
+            ];
+        }
+
+        return [];
+    }
+
+    private static function normalizeNumericGrade(string $gradeString): string
+    {
+        $grade = (int) $gradeString;
+
+        if ($grade < 0 || $grade > 13 || ((float) $grade !== (float) $gradeString)) {
+            return 'OT';
+        }
+
+        if (0 === $grade) {
+            return 'KG';
+        }
+
+        // 01 to 13
+        return sprintf('%02d', $grade);
+    }
+
+    private static function normalizeStringGrade(string $grade): string
+    {
+        if ('K' === $grade) {
+            return 'KG';
+        }
+
+        if (in_array($grade, [
+            'IT',
+            'PR',
+            'PK',
+            'TK',
+            'KG',
+            'AS',
+            'BA',
+            'PB',
+            'MD',
+            'PM',
+            'DO',
+            'PD',
+            'AE',
+            'PT',
+            'OT',
+        ], true)) {
+            return $grade;
+        }
+
+        return 'OT';
+    }
+}


### PR DESCRIPTION
Process the education level string when importing a spreadsheet
(or json file), and normalize the values.

resolves #687

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/688)
<!-- Reviewable:end -->
