### PR TITLE
Update travis to use minimal base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,12 @@ sudo: required
 env:
   global:
     - COMMIT=${TRAVIS_COMMIT::8}
-    - DOCKER_COMPOSE_VERSION=1.21.2
+    - DOCKER_COMPOSE_VERSION=1.23.2
     - FIREBASE_PREFIX=${FIREBASE_PREFIX:-travis}-${TRAVIS_BUILD_NUMBER}
 
-language: php
+dist: xenial
 
-php:
-  - '7.1'
+language: minimal
 
 cache:
   directories:
@@ -25,6 +24,11 @@ services:
   - docker
 
 addons:
+  apt:
+    sources:
+      - docker-xenial
+    packages:
+      - docker-ce
   sonarcloud:
     organization: "opensalt"
 
@@ -79,7 +83,9 @@ after_success:
 after_failure:
   - echo "Tests FAILED"
   - ./bin/console --env=prod firebase:clear
+  - echo 'PHP errors...' && echo -en 'travis_fold:start:log.errors\\r'
   - ./ci/travis/send_errors.sh
+  - echo -en 'travis_fold:end:log.errors\\r'
 
 
 #before_deploy:
@@ -106,6 +112,5 @@ after_script:
   - docker-compose -f docker/docker-compose.yml -f docker/docker-compose.tools.yml down -v
 
 notifications:
-  hipchat:
-    rooms:
-      secure: nnj4UI4oXCCT3UYPCcaXONoKmtj6Hf7zM7ysDmWlqBaH0oJiZIbReF3IqBl4EoOkteZ+gBJBVfstmTsTCPkgfCC7rrKj2KkkINS4rskzFUmvG84cJmsFyzdOJv3ArXiWU4YNdZJGggP0lXwxr/fNx8t1VVpdHzt6kHDm3pemoc/yuRiljJI4oPDTkNVIiuD/sRtk0OZt4CFDA3Dnm6fUtwKVBDQ3sEQpu2hCkx1BycISnpkksx+BmYlbmik3jBbdov7dwLOF2HS8YAeDH1Qo6y8Dh8Y94Vtx48w2eX5E0SUdlQj9FPRGh5MrVWxY5/UH1CNNFiTgfkqC+YQ3JR6AFMhSWJWVRnxsGws12GpK3J6WGVRPmAYweTcljJn1HTHi+vjfZbajsqZsEN6XrFXA6I/TPIjfVQO9Gb2HeK/DxMjbYTiReg7Sb4JMJwER63d2yyxmirusnR3JpH86c5z1YSa8I4T3vLKrzPuterj8f99kYHb4Yb8KcVF3aSTxI0ObmKR5AZqWNw0JX6yopUf2Y8barI2/FwpMpkUNaun7U0bECPhq9qdfXWh0BSjpHnXSRXsQH3e4PHDOPLcaK0itf8JT8UdCugo+cTrdIJMv72Jfno5AjG5lduSsWDErBOFj/y7pKDbgHrO1oVfrb5CgeXs9xumEWIW9efjjr5C+fUw=
+  slack:
+    secure: RNpMIVa23IbyLyIc4g5C0Hgk7h9zN5H8VNbTTNkpDTrkvpg77zjrcbkMLUaX2C1+4YYUjwiCrwD/T26icbTft3cnSaUJlRX9vUnsVApnnXbY5Y3saHDPvqSAJodJLB2dXKJ8xqKaEV5N780EbxU5dOwy52A+4TEQSuoS6jWDChnqdJLqNocMGE5w+6vHovyuE1/Svjmg7PJmsSOsMk0Prfo9OGFukTNgWuounssmDp9nM3kp9ON64opO9umUoWLpLAWppr1W3Rkj4h1Hq4KKeZ7gkyR2CtpxyhQuAa9xfZk4yIKJp0SS8Rb+rhF5bal9nfmNC1OgfhzskpUpMgbonUaSPytrhy2L4j8S81QyHf53c7+y0RkFvk/1qq4raCbwjXQ35lfmBJvnHUB35JXvBo0G9+mgJJqLKp+bXwyHjOy46aP7UxN3ovL7qFjINclfSihCrrLPJk39LoMQuNHHaVzKVrC+DSfWirD3rzra9WbahJovKdemVYvYFcWi09AGZXC6YWHe3UnnbmWrCaTlU0iwH4s+ikhrAewdfjbagmXYSzl4nslxEegkmBpCRrqYAnRJxqY5dnr2IlUyXAt5Hn8AsmEzIMxNsnYh9Mbyt++mlk1Lcb+a5DtpxvM5aHKTK1pK1f75kEUMjOh4LaEIw6LAE8tBV6AEBi37KoZFJIE=


### PR DESCRIPTION
Update travis-ci to use the minimal xenial image, update docker and
docker-compose, and send notifications to slack instead of hipchat.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/689)
<!-- Reviewable:end -->
