### PR TITLE
Issue758 assoc groups visible

### DIFF
--- a/templates/framework/doc_tree/view.html.twig
+++ b/templates/framework/doc_tree/view.html.twig
@@ -205,11 +205,11 @@
                                             <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#editDocModal" data-alt-document-disabled="true">
                                                 Edit
                                             </button>
-                                            {% if isDraft %}
+                                        {% endif %}
+                                        {% if editorRights and not isDeprecated %}
                                                 <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#manageAssocGroupsModal" data-alt-document-disabled="true">
                                                     Manage Association Groups
                                                 </button>
-                                            {% endif %}
                                         {% endif %}
                                         {% if manageEditorsRights %}
                                             <a href="{{ path('framework_acl_edit', {'id':lsDocId}) }}" class="btn btn-default btn-sm" data-alt-document-disabled="true">Manage Access</a>

--- a/templates/framework/doc_tree/view.html.twig
+++ b/templates/framework/doc_tree/view.html.twig
@@ -201,7 +201,7 @@
                                             Export
                                         </button>
                                         {# use first version if we need to edit the adoptionStatus #}
-                                        {% if editorRights %}
+                                        {% if isDraft %}
                                             <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#editDocModal" data-alt-document-disabled="true">
                                                 Edit
                                             </button>

--- a/templates/framework/doc_tree/view.html.twig
+++ b/templates/framework/doc_tree/view.html.twig
@@ -201,7 +201,7 @@
                                             Export
                                         </button>
                                         {# use first version if we need to edit the adoptionStatus #}
-                                        {% if isDraft %}
+                                        {% if editorRights or isDraft %}
                                             <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#editDocModal" data-alt-document-disabled="true">
                                                 Edit
                                             </button>

--- a/tests/acceptance/features/framework/organization_editor/adopted_framework.feature
+++ b/tests/acceptance/features/framework/organization_editor/adopted_framework.feature
@@ -14,7 +14,7 @@ Feature: A framework marked as "Adopted" should not allow edits
     When I click "Import CASE® file"
     And I upload the adopted CASE file
     And I go to the uploaded framework
-    Then I should not see the button "Manage Association Groups"
+    Then I should see the button "Manage Association Groups"
     And I should not see the button "Add New Child Item"
     And I should not see the button "Import Children"
     And I should not see the button "Update Framework"


### PR DESCRIPTION
Issue #758 

- made edit button dependent on "IsDraft" instead of editor rights
- made Association Groups show when EditorRights and not IsDeprecated (so it will show up for draft or adopted frameworks still only if that editor has Org etc rights)
- changed acceptance test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/795)
<!-- Reviewable:end -->
