### PR TITLE
update length

### DIFF
--- a/assets/js/cftree/view-documentclass.js
+++ b/assets/js/cftree/view-documentclass.js
@@ -1529,7 +1529,7 @@ function ApxDocument(initializer) {
 
                     // TODO: deal with cku, licenceUri
                     // for uri, get it from the ApxDocument
- 
+
                     val = render.escaped(val);
 
                     html += $('<div>').append(
@@ -1812,8 +1812,8 @@ function ApxDocument(initializer) {
         // if item comes from another doc, note that
         if (!empty(doc) && typeof(doc) === "object" && doc !== self) {
             let docTitle = doc.doc.title;
-            if (docTitle.length > 30) {
-                docTitle = docTitle.substr(0, 35);
+            if (docTitle.length > 60) {
+                docTitle = docTitle.substr(0, 65);
                 docTitle = docTitle.replace(/\w+$/, "");
                 docTitle += "…";
             }


### PR DESCRIPTION
Closes #859

Followed the same pattern as the integers before; 60 is completely arbitrary but I don't see many official frameworks that exceed that number. I do however feel strongly enough that if we can show the full framework title it is better, especially for folks like ACT who may put identifying version/other information at the end of the framework title.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/861)
<!-- Reviewable:end -->
