### PR TITLE
Set document for association groups on JSON import

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -78,16 +78,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.116.0",
+            "version": "3.117.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "b0669936681365a6c5201a6d28bfa76553052912"
+                "reference": "3fc3d2c1962f34becc4313c839ed8b659d045114"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b0669936681365a6c5201a6d28bfa76553052912",
-                "reference": "b0669936681365a6c5201a6d28bfa76553052912",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/3fc3d2c1962f34becc4313c839ed8b659d045114",
+                "reference": "3fc3d2c1962f34becc4313c839ed8b659d045114",
                 "shasum": ""
             },
             "require": {
@@ -157,7 +157,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-11-12T19:15:09+00:00"
+            "time": "2019-11-13T19:14:25+00:00"
         },
         {
             "name": "behat/transliterator",
@@ -7566,16 +7566,16 @@
         },
         {
             "name": "symfony/flex",
-            "version": "v1.4.7",
+            "version": "v1.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/flex.git",
-                "reference": "d1b68b9953513408cf89baf9bf4d21feb5e12706"
+                "reference": "f5bfc79c1f5bed6b2bb4ca9e49a736c2abc03e8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/flex/zipball/d1b68b9953513408cf89baf9bf4d21feb5e12706",
-                "reference": "d1b68b9953513408cf89baf9bf4d21feb5e12706",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/f5bfc79c1f5bed6b2bb4ca9e49a736c2abc03e8f",
+                "reference": "f5bfc79c1f5bed6b2bb4ca9e49a736c2abc03e8f",
                 "shasum": ""
             },
             "require": {
@@ -7584,9 +7584,9 @@
             },
             "require-dev": {
                 "composer/composer": "^1.0.2",
-                "symfony/dotenv": "^3.4|^4.0",
-                "symfony/phpunit-bridge": "^3.4.19|^4.1.8",
-                "symfony/process": "^2.7|^3.0|^4.0"
+                "symfony/dotenv": "^3.4|^4.0|^5.0",
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8|^5.0",
+                "symfony/process": "^2.7|^3.0|^4.0|^5.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -7611,7 +7611,7 @@
                 }
             ],
             "description": "Composer plugin for Symfony",
-            "time": "2019-11-14T03:42:24+00:00"
+            "time": "2019-11-14T09:25:51+00:00"
         },
         {
             "name": "symfony/form",
@@ -12434,7 +12434,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "? Nette NEON: encodes and decodes NEON file format.",
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",

--- a/src/DataTransformer/CaseJson/DocumentTransformer.php
+++ b/src/DataTransformer/CaseJson/DocumentTransformer.php
@@ -29,6 +29,8 @@ class DocumentTransformer
         $this->definitions = $definitions;
         $doc = $this->findOrCreateDocument($cfDocument);
 
+        $this->updateAssociationGroups($this->definitions->associationGroupings, $doc);
+
         return $this->updateDocument($doc, $cfDocument);
     }
 
@@ -75,5 +77,14 @@ class DocumentTransformer
         }
 
         return $doc;
+    }
+
+    private function updateAssociationGroups(array $associationGroupings, LsDoc $doc): void
+    {
+        foreach ($associationGroupings as $group) {
+            if (null === $group->getLsDoc()) {
+                $group->setLsDoc($doc);
+            }
+        }
     }
 }


### PR DESCRIPTION
The current UI expects association groupings to be linked to a document,
this PR will update the groups imported from a JSON file to ensure that
the value is set.

In the future we need to change this expectation as an association
grouping is a global object that should not "belong" to a document.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/943)
<!-- Reviewable:end -->
