### PR TITLE
Remove @Assert\Date from statusStart and statusEnd

### DIFF
--- a/src/Entity/Framework/LsDoc.php
+++ b/src/Entity/Framework/LsDoc.php
@@ -241,26 +241,22 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
      *
      * @ORM\Column(name="status_start", type="date", nullable=true)
      *
-     * @Assert\Date()
-     *
      * @Serializer\Expose()
      * @Serializer\SerializedName("statusStartDate")
      * @Serializer\Type("DateTime<'Y-m-d'>")
      */
-    private $statusStart;
+    private ?\DateTimeInterface $statusStart = null;
 
     /**
      * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="status_end", type="date", nullable=true)
      *
-     * @Assert\Date()
-     *
      * @Serializer\Expose()
      * @Serializer\SerializedName("statusEndDate")
      * @Serializer\Type("DateTime<'Y-m-d'>")
      */
-    private $statusEnd;
+    private ?\DateTimeInterface $statusEnd = null;
 
     /**
      * @var LsDefLicence|null

--- a/src/Entity/Framework/LsItem.php
+++ b/src/Entity/Framework/LsItem.php
@@ -252,28 +252,24 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
      *
      * @ORM\Column(name="status_start", type="date", nullable=true)
      *
-     * @Assert\Date()
-     *
      * @Serializer\Expose()
      * @Serializer\SerializedName("statusStartDate")
      * @Serializer\AccessType("public_method")
      * @Serializer\Type("DateTime<'Y-m-d'>")
      */
-    private $statusStart;
+    private ?\DateTimeInterface $statusStart = null;
 
     /**
      * @var \DateTimeInterface|null
      *
      * @ORM\Column(name="status_end", type="date", nullable=true)
      *
-     * @Assert\Date()
-     *
      * @Serializer\Expose()
      * @Serializer\SerializedName("statusEndDate")
      * @Serializer\AccessType("public_method")
      * @Serializer\Type("DateTime<'Y-m-d'>")
      */
-    private $statusEnd;
+    private ?\DateTimeInterface $statusEnd = null;
 
     /**
      * @var LsDefLicence|null
@@ -781,6 +777,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
             $childIds[$id] = $id;
             $childIds = array_merge($childIds, $child->getDescendantIds());
         }
+
         return $childIds;
     }
 

--- a/tests/_support/Page/Framework.php
+++ b/tests/_support/Page/Framework.php
@@ -800,6 +800,8 @@ class Framework implements Context
             'adoptionStatus' => 'Draft',
             'note' => $note,
             'license' => 'Attribution 4.0 International',
+            'statusStart' => '2020-01-01',
+            'statusEnd' => '2020-01-02',
         ];
 
         $I->fillField(self::$fwTitle, $framework);
@@ -812,6 +814,11 @@ class Framework implements Context
         //       $I->selectOption('.select2-search__field', array('text' => 'Math')); //Subject field
         $I->selectOption('ls_doc_create[language]', ['value' => $this->frameworkData['language']]);
         $I->selectOption('ls_doc_create[adoptionStatus]', ['value' => $this->frameworkData['adoptionStatus']]);
+        $statusStart = $this->frameworkData['statusStart'];
+        //$I->fillField('#ls_doc_statusStart', $statusStart);
+        $I->executeJS("$('#ls_doc_create_statusStart').val('{$statusStart}');");
+        $statusEnd = $this->frameworkData['statusEnd'];
+        $I->executeJS("$('#ls_doc_create_statusEnd').val('{$statusEnd}');");
         $I->fillField('#ls_doc_create_note', $note);
         // Choose one license
         $I->click(Locator::lastElement('.select2-container--bootstrap'));
@@ -821,6 +828,7 @@ class Framework implements Context
         $I->click('Create');
 
         try {
+            $I->waitForElementNotVisible('#ls_doc_create', 30);
             $I->waitForElementVisible('#docTitle', 30);
         } catch (\Exception $e) {
             ++static::$failedCreateCount;


### PR DESCRIPTION
Using @Assert\Date to check a date field was removed in Symfony 5.

fixes #1089

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/1092)
<!-- Reviewable:end -->
