### PR TITLE
Update to PHPSpreadsheet 1.23

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -63,7 +63,7 @@
         "nelmio/cors-bundle": "^2.0",
         "nelmio/security-bundle": "^3.0",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "phpoffice/phpspreadsheet": "~1.22.0",
+        "phpoffice/phpspreadsheet": "~1.23.0",
         "phpoffice/phpword": "^0.18.0",
         "qandidate/toggle-bundle": "^1.4.0",
         "ramsey/uuid": "^4.0",

--- a/core/composer.lock
+++ b/core/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a12cbb66cba91efece23c15429c40ad",
+    "content-hash": "0261eb2f2b00c89dc3f6d4abbb3fdbcf",
     "packages": [
         {
             "name": "antishov/doctrine-extensions-bundle",
@@ -4572,16 +4572,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.22.0",
+            "version": "1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "3a9e29b4f386a08a151a33578e80ef1747037a48"
+                "reference": "21e4cf62699eebf007db28775f7d1554e612ed9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/3a9e29b4f386a08a151a33578e80ef1747037a48",
-                "reference": "3a9e29b4f386a08a151a33578e80ef1747037a48",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/21e4cf62699eebf007db28775f7d1554e612ed9e",
+                "reference": "21e4cf62699eebf007db28775f7d1554e612ed9e",
                 "shasum": ""
             },
             "require": {
@@ -4605,7 +4605,7 @@
                 "php": "^7.3 || ^8.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0",
-                "psr/simple-cache": "^1.0"
+                "psr/simple-cache": "^1.0 || ^2.0"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "dev-master",
@@ -4670,9 +4670,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.22.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.23.0"
             },
-            "time": "2022-02-18T12:57:07+00:00"
+            "time": "2022-04-24T13:53:10+00:00"
         },
         {
             "name": "phpoffice/phpword",
@@ -5198,25 +5198,25 @@
         },
         {
             "name": "psr/simple-cache",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+                "reference": "8707bf3cea6f710bf6ef05491234e3ab06f6432a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
-                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/8707bf3cea6f710bf6ef05491234e3ab06f6432a",
+                "reference": "8707bf3cea6f710bf6ef05491234e3ab06f6432a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=8.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -5231,7 +5231,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for simple caching",
@@ -5243,9 +5243,9 @@
                 "simple-cache"
             ],
             "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/master"
+                "source": "https://github.com/php-fig/simple-cache/tree/2.0.0"
             },
-            "time": "2017-10-23T01:57:42+00:00"
+            "time": "2021-10-29T13:22:09+00:00"
         },
         {
             "name": "qandidate/toggle",

--- a/core/src/Service/ExcelExport.php
+++ b/core/src/Service/ExcelExport.php
@@ -14,7 +14,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class ExcelExport
 {
-    private static array $customItemFields;
+    private static ?array $customItemFields = null;
 
     public function __construct(private EntityManagerInterface $entityManager)
     {

--- a/core/src/Service/ExcelExport.php
+++ b/core/src/Service/ExcelExport.php
@@ -2,9 +2,9 @@
 
 namespace App\Service;
 
+use App\Entity\Framework\AdditionalField;
 use App\Entity\Framework\LsDoc;
 use App\Entity\Framework\LsItem;
-use App\Entity\Framework\AdditionalField;
 use App\Util\Compare;
 use Doctrine\ORM\EntityManagerInterface;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
@@ -14,7 +14,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 
 final class ExcelExport
 {
-    private static $customItemFields;
+    private static array $customItemFields;
 
     public function __construct(private EntityManagerInterface $entityManager)
     {
@@ -64,7 +64,7 @@ final class ExcelExport
         return $phpExcelObject;
     }
 
-    protected function getSmartLevel(array $items, $parentId, array $itemsArray, array &$smartLevel): void
+    private function getSmartLevel(array $items, $parentId, array $itemsArray, array &$smartLevel): void
     {
         $j = 1;
 
@@ -182,7 +182,7 @@ final class ExcelExport
         $phpExcelObject->setActiveSheetIndex(0);
     }
 
-    protected function addItemRows(array $set, Worksheet $activeSheet, int &$j, array $items, array $smartLevel): void
+    private function addItemRows(array $set, Worksheet $activeSheet, int &$j, array $items, array $smartLevel): void
     {
         foreach ($set as $child) {
             $item = $items[$child['id']];
@@ -202,7 +202,7 @@ final class ExcelExport
         }
     }
 
-    protected function addItemRow(Worksheet $sheet, int $row, array $rowData): void
+    private function addItemRow(Worksheet $sheet, int $row, array $rowData): void
     {
         $columns = [
             'A' => '[identifier]',
@@ -230,7 +230,7 @@ final class ExcelExport
         }
     }
 
-    protected function addAssociationRow(Worksheet $sheet, int $row, array $rowData): void
+    private function addAssociationRow(Worksheet $sheet, int $row, array $rowData): void
     {
         $columns = [
             'A' => '[identifier]',
@@ -250,13 +250,13 @@ final class ExcelExport
         }
     }
 
-    protected function addCellIfExists(Worksheet $sheet, string $col, int $row, array $rowData, string $propertyPath): void
+    private function addCellIfExists(Worksheet $sheet, string $col, int $row, array $rowData, string $propertyPath): void
     {
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         try {
             $value = $propertyAccessor->getValue($rowData, $propertyPath);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Treat value as unset if the path to it does not work
             return;
         }
@@ -266,13 +266,13 @@ final class ExcelExport
         }
     }
 
-    protected function setAdditionalFields(Worksheet $sheet): void
+    private function setAdditionalFields(Worksheet $sheet): void
     {
         $column = 13;
 
         if (count(self::$customItemFields) > 0) {
             foreach (self::$customItemFields as $cf) {
-                $sheet->setCellValueByColumnAndRow($column, 1, $cf);
+                $sheet->setCellValue([$column, 1], $cf);
                 ++$column;
             }
         }

--- a/core/src/Service/ExcelImport.php
+++ b/core/src/Service/ExcelImport.php
@@ -17,7 +17,7 @@ use Ramsey\Uuid\Uuid;
 
 final class ExcelImport
 {
-    private static $itemCustomFields;
+    private static ?array $itemCustomFields = null;
 
     public function __construct(private EntityManagerInterface $entityManager)
     {
@@ -366,13 +366,11 @@ final class ExcelImport
 
     private function getCellValueOrNull(Worksheet $sheet, int $col, int $row)
     {
-        if (!$sheet->cellExistsByColumnAndRow($col, $row)) {
+        if (!$sheet->cellExists([$col, $row])) {
             return null;
         }
 
-        $cell = $sheet->getCellByColumnAndRow($col, $row);
-
-        return $cell->getValue();
+        return $sheet->getCellByColumnAndRow($col, $row)->getValue();
     }
 
     private function checkRemovedItems(LsDoc $doc, array $array): void

--- a/core/src/Service/SubtypeUpdater.php
+++ b/core/src/Service/SubtypeUpdater.php
@@ -170,13 +170,11 @@ class SubtypeUpdater
 
     protected function getValueFromSheet(Worksheet $sheet, int $columnIndex, int $rowIndex): ?string
     {
-        if (!$sheet->cellExistsByColumnAndRow($columnIndex, $rowIndex)) {
+        if (!$sheet->cellExists([$columnIndex, $rowIndex])) {
             return null;
         }
 
-        $cell = $sheet->getCellByColumnAndRow($columnIndex, $rowIndex);
-
-        return $cell->getFormattedValue();
+        return $sheet->getCell([$columnIndex, $rowIndex])->getFormattedValue();
     }
 
     protected function replaceAssociation(?string $origin, ?string $destination, ?string $newType, ?string $subtype, ?string $annotation): string


### PR DESCRIPTION
 - update to phpspreadsheet 1.23.0
 - use [col,row] syntax instead of deprecated *ByColumnAndRow() methods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/1822)
<!-- Reviewable:end -->
