### PR TITLE
Updates to PHP 8.1

### DIFF
--- a/core/composer.lock
+++ b/core/composer.lock
@@ -136,16 +136,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.222.5",
+            "version": "3.222.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "26596820b043db985bf7c9deb98aa2234f6054cb"
+                "reference": "03d35eef5c509798d2c08587cfd9a7c33afe2260"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/26596820b043db985bf7c9deb98aa2234f6054cb",
-                "reference": "26596820b043db985bf7c9deb98aa2234f6054cb",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/03d35eef5c509798d2c08587cfd9a7c33afe2260",
+                "reference": "03d35eef5c509798d2c08587cfd9a7c33afe2260",
                 "shasum": ""
             },
             "require": {
@@ -221,9 +221,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.222.5"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.222.7"
             },
-            "time": "2022-05-04T20:25:34+00:00"
+            "time": "2022-05-06T18:16:59+00:00"
         },
         {
             "name": "behat/transliterator",
@@ -1960,16 +1960,16 @@
         },
         {
             "name": "doctrine/persistence",
-            "version": "2.5.2",
+            "version": "2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/persistence.git",
-                "reference": "4276c6cbc0ca692c190f650a2678623bf04af2d2"
+                "reference": "d7edf274b6d35ad82328e223439cc2bb2f92bd9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/4276c6cbc0ca692c190f650a2678623bf04af2d2",
-                "reference": "4276c6cbc0ca692c190f650a2678623bf04af2d2",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/d7edf274b6d35ad82328e223439cc2bb2f92bd9e",
+                "reference": "d7edf274b6d35ad82328e223439cc2bb2f92bd9e",
                 "shasum": ""
             },
             "require": {
@@ -2042,7 +2042,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/2.5.2"
+                "source": "https://github.com/doctrine/persistence/tree/2.5.3"
             },
             "funding": [
                 {
@@ -2058,7 +2058,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-02T17:29:02+00:00"
+            "time": "2022-05-03T09:16:53+00:00"
         },
         {
             "name": "doctrine/sql-formatter",
@@ -13264,12 +13264,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "2658dd564ed1a63989404083d7ccb9cb10e07701"
+                "reference": "c99945852fb9e9de3bc89c90f24b4c8ef47668fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/2658dd564ed1a63989404083d7ccb9cb10e07701",
-                "reference": "2658dd564ed1a63989404083d7ccb9cb10e07701",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/c99945852fb9e9de3bc89c90f24b4c8ef47668fd",
+                "reference": "c99945852fb9e9de3bc89c90f24b4c8ef47668fd",
                 "shasum": ""
             },
             "conflict": {
@@ -13321,8 +13321,9 @@
                 "concrete5/concrete5": "<9",
                 "concrete5/core": "<8.5.7",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
+                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3",
                 "contao/core": ">=2,<3.5.39",
-                "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|= 4.10.0",
+                "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
                 "craftcms/cms": "<3.7.29",
@@ -13744,7 +13745,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-05T14:08:42+00:00"
+            "time": "2022-05-06T13:19:01+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/core/ecs.php
+++ b/core/ecs.php
@@ -12,6 +12,7 @@ use PhpCsFixer\Fixer\ControlStructure\NoTrailingCommaInListCallFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer;
+use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
@@ -25,13 +26,19 @@ use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symplify\CodingStandard\Fixer\Commenting\ParamReturnAndVarTagMalformsFixer;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+use Symplify\EasyCodingStandard\ValueObject\Option;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
+    $parameters->set(Option::PARALLEL, true);
+
+    $services = $containerConfigurator->services();
 
     $containerConfigurator->import(SetList::CLEAN_CODE);
     $containerConfigurator->import(SetList::PSR_12);
     $containerConfigurator->import(SetList::SYMFONY);
+
+    $services->set(NoUnusedImportsFixer::class);
 
     $parameters->set('skip', [
         'PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer' => null, // Tries to add a space like &$param -> & $param in method var lists

--- a/core/phpstan.neon.dist
+++ b/core/phpstan.neon.dist
@@ -17,6 +17,7 @@ parameters:
 		container_xml_path: './var/cache/dev/App_KernelDevDebugContainer.xml'
 	doctrine:
 		objectManagerLoader: './tests/object-manager.php'
+		allowNullablePropertyForRequiredField: true
 
 	treatPhpDocTypesAsCertain: false
 	checkMissingIterableValueType: false
@@ -24,3 +25,5 @@ parameters:
 
 	ignoreErrors:
 		- "#Property .* type mapping mismatch\\: property can contain string\\|null but database expects string\\.$#"
+		- "#Property .* type mapping mismatch\\: database can contain string.* but property expects int\\|null\\.$#"
+		- "#Parameter .* of attribute class .*Entity constructor expects class-string.*EntityRepository.* .*Repository. given\\.$#"

--- a/core/src/Command/CommandDispatcherTrait.php
+++ b/core/src/Command/CommandDispatcherTrait.php
@@ -4,14 +4,13 @@ namespace App\Command;
 
 use App\Event\CommandEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 trait CommandDispatcherTrait
 {
     protected ?EventDispatcherInterface $dispatcher = null;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setDispatcher(EventDispatcherInterface $dispatcher): void
     {
         $this->dispatcher = $dispatcher;

--- a/core/src/Command/Comment/AddCommentCommand.php
+++ b/core/src/Command/Comment/AddCommentCommand.php
@@ -13,10 +13,9 @@ class AddCommentCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\Type("string")
-     * @Assert\NotNull()
      */
+    #[Assert\Type('string')]
+    #[Assert\NotNull]
     private $itemType;
 
     /**
@@ -35,38 +34,33 @@ class AddCommentCommand extends BaseCommand
 
     /**
      * @var User
-     *
-     * @Assert\Type(User::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(User::class)]
+    #[Assert\NotNull]
     private $user;
 
     /**
      * @var string
-     *
-     * @Assert\Type("string")
      */
+    #[Assert\Type('string')]
     private $content;
 
     /**
      * @var int
-     *
-     * @Assert\Type("int")
      */
+    #[Assert\Type('int')]
     private $parentId;
 
     /**
      * @var Comment
-     *
-     * @Assert\Type(Comment::class)
      */
+    #[Assert\Type(Comment::class)]
     private $comment;
 
     /**
      * @var string
-     *
-     * @Assert\Type("string")
      */
+    #[Assert\Type('string')]
     private $fileUrl;
 
     private $mimeType;

--- a/core/src/Command/Comment/DeleteCommentCommand.php
+++ b/core/src/Command/Comment/DeleteCommentCommand.php
@@ -10,10 +10,9 @@ class DeleteCommentCommand extends BaseCommand
 {
     /**
      * @var Comment
-     *
-     * @Assert\Type(Comment::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(Comment::class)]
+    #[Assert\NotNull]
     private $comment;
 
     public function __construct(Comment $comment)

--- a/core/src/Command/Comment/DownvoteCommentCommand.php
+++ b/core/src/Command/Comment/DownvoteCommentCommand.php
@@ -11,18 +11,16 @@ class DownvoteCommentCommand extends BaseCommand
 {
     /**
      * @var Comment
-     *
-     * @Assert\Type(Comment::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(Comment::class)]
+    #[Assert\NotNull]
     private $comment;
 
     /**
      * @var User
-     *
-     * @Assert\Type(User::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(User::class)]
+    #[Assert\NotNull]
     private $user;
 
     public function __construct(Comment $comment, User $user)

--- a/core/src/Command/Comment/UpdateCommentCommand.php
+++ b/core/src/Command/Comment/UpdateCommentCommand.php
@@ -10,19 +10,17 @@ class UpdateCommentCommand extends BaseCommand
 {
     /**
      * @var Comment
-     *
-     * @Assert\Type(Comment::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(Comment::class)]
+    #[Assert\NotNull]
     private $comment;
 
     /**
      * @var string
-     *
-     * @Assert\Type("string")
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\Type('string')]
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $newContent;
 
     public function __construct(Comment $comment, string $newContent)

--- a/core/src/Command/Comment/UpvoteCommentCommand.php
+++ b/core/src/Command/Comment/UpvoteCommentCommand.php
@@ -11,18 +11,16 @@ class UpvoteCommentCommand extends BaseCommand
 {
     /**
      * @var Comment
-     *
-     * @Assert\Type(Comment::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(Comment::class)]
+    #[Assert\NotNull]
     private $comment;
 
     /**
      * @var User
-     *
-     * @Assert\Type(User::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(User::class)]
+    #[Assert\NotNull]
     private $user;
 
     public function __construct(Comment $comment, User $user)

--- a/core/src/Command/Email/AbstractSendEmailCommand.php
+++ b/core/src/Command/Email/AbstractSendEmailCommand.php
@@ -9,8 +9,8 @@ abstract class AbstractSendEmailCommand extends BaseCommand
 {
     /**
      * @var string|null
-     * @Assert\Email()
      */
+    #[Assert\Email]
     private $recipient;
 
     public function __construct(?string $recipient)

--- a/core/src/Command/Framework/AddAssociationCommand.php
+++ b/core/src/Command/Framework/AddAssociationCommand.php
@@ -10,10 +10,9 @@ class AddAssociationCommand extends BaseCommand
 {
     /**
      * @var LsAssociation
-     *
-     * @Assert\Type(LsAssociation::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsAssociation::class)]
+    #[Assert\NotNull]
     private $association;
 
     /**

--- a/core/src/Command/Framework/AddAssociationGroupCommand.php
+++ b/core/src/Command/Framework/AddAssociationGroupCommand.php
@@ -10,10 +10,9 @@ class AddAssociationGroupCommand extends BaseCommand
 {
     /**
      * @var LsDefAssociationGrouping
-     *
-     * @Assert\Type(LsDefAssociationGrouping::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefAssociationGrouping::class)]
+    #[Assert\NotNull]
     private $associationGrouping;
 
     /**

--- a/core/src/Command/Framework/AddConceptCommand.php
+++ b/core/src/Command/Framework/AddConceptCommand.php
@@ -10,10 +10,9 @@ class AddConceptCommand extends BaseCommand
 {
     /**
      * @var LsDefConcept
-     *
-     * @Assert\Type(LsDefConcept::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefConcept::class)]
+    #[Assert\NotNull]
     private $concept;
 
     public function __construct(LsDefConcept $concept)

--- a/core/src/Command/Framework/AddDocumentCommand.php
+++ b/core/src/Command/Framework/AddDocumentCommand.php
@@ -10,10 +10,9 @@ class AddDocumentCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     /**

--- a/core/src/Command/Framework/AddExemplarToItemCommand.php
+++ b/core/src/Command/Framework/AddExemplarToItemCommand.php
@@ -11,33 +11,29 @@ class AddExemplarToItemCommand extends BaseCommand
 {
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     private $item;
 
     /**
      * @var string
-     *
-     * @Assert\Type("string")
-     * @Assert\NotNull()
-     * @Assert\Length(max="300")
      */
+    #[Assert\Type('string')]
+    #[Assert\NotNull]
+    #[Assert\Length(max: 300)]
     private $url;
 
     /**
      * @var string|null
-     *
-     * @Assert\Type("string")
      */
+    #[Assert\Type('string')]
     private $annotation;
 
     /**
      * @var LsAssociation|null
-     *
-     * @Assert\Type(LsAssociation::class)
      */
+    #[Assert\Type(LsAssociation::class)]
     private $association;
 
     /**

--- a/core/src/Command/Framework/AddExternalDocCommand.php
+++ b/core/src/Command/Framework/AddExternalDocCommand.php
@@ -8,46 +8,26 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class AddExternalDocCommand extends BaseCommand
 {
-    /**
-     * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
-     */
-    private $doc;
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
+    private LsDoc $doc;
 
-    /**
-     * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     * @Assert\Choice({"true", "false"})
-     */
-    private $autoload;
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    #[Assert\Choice(['true', 'false'])]
+    private string $autoload;
 
-    /**
-     * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     */
-    private $url;
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    private string $url;
 
-    /**
-     * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     */
-    private $title;
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    private string $title;
 
-    /**
-     * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     */
-    private $identifier;
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    private string $identifier;
 
     public function __construct(LsDoc $doc, string $identifier, string $autoload, string $url, string $title)
     {

--- a/core/src/Command/Framework/AddGradeCommand.php
+++ b/core/src/Command/Framework/AddGradeCommand.php
@@ -10,10 +10,9 @@ class AddGradeCommand extends BaseCommand
 {
     /**
      * @var LsDefGrade
-     *
-     * @Assert\Type(LsDefGrade::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefGrade::class)]
+    #[Assert\NotNull]
     private $grade;
 
     public function __construct(LsDefGrade $grade)

--- a/core/src/Command/Framework/AddItemTypeCommand.php
+++ b/core/src/Command/Framework/AddItemTypeCommand.php
@@ -10,10 +10,9 @@ class AddItemTypeCommand extends BaseCommand
 {
     /**
      * @var LsDefItemType
-     *
-     * @Assert\Type(LsDefItemType::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefItemType::class)]
+    #[Assert\NotNull]
     private $itemType;
 
     public function __construct(LsDefItemType $itemType)

--- a/core/src/Command/Framework/AddLicenceCommand.php
+++ b/core/src/Command/Framework/AddLicenceCommand.php
@@ -10,10 +10,9 @@ class AddLicenceCommand extends BaseCommand
 {
     /**
      * @var LsDefLicence
-     *
-     * @Assert\Type(LsDefLicence::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefLicence::class)]
+    #[Assert\NotNull]
     private $licence;
 
     public function __construct(LsDefLicence $licence)

--- a/core/src/Command/Framework/AddSubjectCommand.php
+++ b/core/src/Command/Framework/AddSubjectCommand.php
@@ -10,10 +10,9 @@ class AddSubjectCommand extends BaseCommand
 {
     /**
      * @var LsDefSubject
-     *
-     * @Assert\Type(LsDefSubject::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefSubject::class)]
+    #[Assert\NotNull]
     private $subject;
 
     public function __construct(LsDefSubject $subject)

--- a/core/src/Command/Framework/AddTreeAssociationCommand.php
+++ b/core/src/Command/Framework/AddTreeAssociationCommand.php
@@ -11,91 +11,50 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class AddTreeAssociationCommand extends BaseCommand
 {
-    /**
-     * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
-     */
-    private $doc;
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
+    private LsDoc $doc;
 
-    /**
-     * @var string
-     *
-     * @Assert\Type("string")
-     * @Assert\NotNull()
-     */
-    private $type;
+    #[Assert\Type('string')]
+    #[Assert\NotNull]
+    private string $type;
 
-    /**
-     * @var array
-     *
-     * @Assert\Type("array")
-     * @Assert\NotNull()
-     * @Assert\Collection(
-     *     fields = {
-     *         "id" = {
-     *             @Assert\Type("string")
-     *         },
-     *         "identifier" = {
-     *             @Assert\Type("string")
-     *         },
-     *         "uri" = {
-     *             @Assert\Type("string")
-     *         },
-     *         "externalDoc" = {
-     *             @Assert\Type("string")
-     *         }
-     *     },
-     *     allowMissingFields = true
-     * )
-     */
-    private $origin;
+    #[Assert\Type('array')]
+    #[Assert\NotNull]
+    #[Assert\Collection(
+        fields: [
+            'id' => new Assert\Type('string'),
+            'identifier' => new Assert\Type('string'),
+            'uri' => new Assert\Type('string'),
+            'externalDoc' => new Assert\Type('string'),
+        ],
+        allowMissingFields: true,
+    )]
+    private array $origin;
 
-    /**
-     * @var array
-     *
-     * @Assert\Type("array")
-     * @Assert\NotNull()
-     * @Assert\Collection(
-     *     fields = {
-     *         "id" = {
-     *             @Assert\Type("string")
-     *         },
-     *         "identifier" = {
-     *             @Assert\Type("string")
-     *         },
-     *         "uri" = {
-     *             @Assert\Type("string")
-     *         },
-     *         "externalDoc" = {
-     *             @Assert\Type("string")
-     *         }
-     *     },
-     *     allowMissingFields = true
-     * )
-     */
-    private $dest;
+    #[Assert\Type('array')]
+    #[Assert\NotNull]
+    #[Assert\Collection(
+        fields: [
+            'id' => new Assert\Type('string'),
+            'identifier' => new Assert\Type('string'),
+            'uri' => new Assert\Type('string'),
+            'externalDoc' => new Assert\Type('string'),
+        ],
+        allowMissingFields: true,
+    )]
+    private array $dest;
 
-    /**
-     * @var string|null
-     *
-     * @Assert\Type("string")
-     */
-    private $assocGroup;
+    #[Assert\Type('string')]
+    private ?string $assocGroup;
 
-    /**
-     * @var string|null
-     *
-     * @Assert\Type("string")
-     */
-    private $annotation;
+    #[Assert\Type('string')]
+    private ?string $annotation;
 
     /**
      * @var LsAssociation|null
-     *
-     * @Assert\Type(LsAssociation::class)
      */
+    #[Assert\Type(LsAssociation::class)]
     private $association;
 
     /**
@@ -161,9 +120,7 @@ class AddTreeAssociationCommand extends BaseCommand
         $this->allowedSubtypes = $subtypes;
     }
 
-    /**
-     * @Assert\Callback()
-     */
+    #[Assert\Callback]
     public function validate(ExecutionContextInterface $context, $payload): void
     {
         if (empty($this->origin['id']) && empty($this->origin['identifier'])) {

--- a/core/src/Command/Framework/ChangeItemParentCommand.php
+++ b/core/src/Command/Framework/ChangeItemParentCommand.php
@@ -10,10 +10,9 @@ class ChangeItemParentCommand extends BaseCommand
 {
     /**
      * @var ChangeLsItemParentDTO
-     *
-     * @Assert\Type(ChangeLsItemParentDTO::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(ChangeLsItemParentDTO::class)]
+    #[Assert\NotNull]
     private $dto;
 
     /**

--- a/core/src/Command/Framework/CloneFrameworkCommand.php
+++ b/core/src/Command/Framework/CloneFrameworkCommand.php
@@ -10,10 +10,9 @@ class CloneFrameworkCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     public function __construct(LsDoc $doc)

--- a/core/src/Command/Framework/CopyDocumentToItemCommand.php
+++ b/core/src/Command/Framework/CopyDocumentToItemCommand.php
@@ -10,10 +10,9 @@ class CopyDocumentToItemCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $fromDoc;
 
     /**

--- a/core/src/Command/Framework/CopyFrameworkCommand.php
+++ b/core/src/Command/Framework/CopyFrameworkCommand.php
@@ -10,10 +10,9 @@ class CopyFrameworkCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $fromDoc;
 
     /**

--- a/core/src/Command/Framework/CopyItemToDocCommand.php
+++ b/core/src/Command/Framework/CopyItemToDocCommand.php
@@ -9,10 +9,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class CopyItemToDocCommand extends BaseCommand
 {
-    /**
-     * @Assert\Type(CopyToLsDocDTO::class)
-     * @Assert\NotNull()
-     */
+    #[Assert\Type(CopyToLsDocDTO::class)]
+    #[Assert\NotNull]
     private CopyToLsDocDTO $dto;
 
     private LsItem $newItem;

--- a/core/src/Command/Framework/DeleteAssociationCommand.php
+++ b/core/src/Command/Framework/DeleteAssociationCommand.php
@@ -10,10 +10,9 @@ class DeleteAssociationCommand extends BaseCommand
 {
     /**
      * @var LsAssociation
-     *
-     * @Assert\Type(LsAssociation::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsAssociation::class)]
+    #[Assert\NotNull]
     private $association;
 
     public function __construct(LsAssociation $association)

--- a/core/src/Command/Framework/DeleteAssociationGroupCommand.php
+++ b/core/src/Command/Framework/DeleteAssociationGroupCommand.php
@@ -10,10 +10,9 @@ class DeleteAssociationGroupCommand extends BaseCommand
 {
     /**
      * @var LsDefAssociationGrouping
-     *
-     * @Assert\Type(LsDefAssociationGrouping::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefAssociationGrouping::class)]
+    #[Assert\NotNull]
     private $associationGrouping;
 
     public function __construct(LsDefAssociationGrouping $associationGrouping)

--- a/core/src/Command/Framework/DeleteConceptCommand.php
+++ b/core/src/Command/Framework/DeleteConceptCommand.php
@@ -10,10 +10,9 @@ class DeleteConceptCommand extends BaseCommand
 {
     /**
      * @var LsDefConcept
-     *
-     * @Assert\Type(LsDefConcept::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefConcept::class)]
+    #[Assert\NotNull]
     private $concept;
 
     public function __construct(LsDefConcept $concept)

--- a/core/src/Command/Framework/DeleteDocumentCommand.php
+++ b/core/src/Command/Framework/DeleteDocumentCommand.php
@@ -8,10 +8,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class DeleteDocumentCommand extends BaseCommand
 {
-    /**
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
-     */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private LsDoc $doc;
 
     private ?\Closure $callback;

--- a/core/src/Command/Framework/DeleteGradeCommand.php
+++ b/core/src/Command/Framework/DeleteGradeCommand.php
@@ -10,10 +10,9 @@ class DeleteGradeCommand extends BaseCommand
 {
     /**
      * @var LsDefGrade
-     *
-     * @Assert\Type(LsDefGrade::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefGrade::class)]
+    #[Assert\NotNull]
     private $grade;
 
     public function __construct(LsDefGrade $grade)

--- a/core/src/Command/Framework/DeleteItemCommand.php
+++ b/core/src/Command/Framework/DeleteItemCommand.php
@@ -10,10 +10,9 @@ class DeleteItemCommand extends BaseCommand
 {
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     private $item;
 
     /**

--- a/core/src/Command/Framework/DeleteItemTypeCommand.php
+++ b/core/src/Command/Framework/DeleteItemTypeCommand.php
@@ -10,10 +10,9 @@ class DeleteItemTypeCommand extends BaseCommand
 {
     /**
      * @var LsDefItemType
-     *
-     * @Assert\Type(LsDefItemType::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefItemType::class)]
+    #[Assert\NotNull]
     private $itemType;
 
     public function __construct(LsDefItemType $itemType)

--- a/core/src/Command/Framework/DeleteItemWithChildrenCommand.php
+++ b/core/src/Command/Framework/DeleteItemWithChildrenCommand.php
@@ -10,10 +10,9 @@ class DeleteItemWithChildrenCommand extends BaseCommand
 {
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     private $item;
 
     /**

--- a/core/src/Command/Framework/DeleteLicenceCommand.php
+++ b/core/src/Command/Framework/DeleteLicenceCommand.php
@@ -10,10 +10,9 @@ class DeleteLicenceCommand extends BaseCommand
 {
     /**
      * @var LsDefLicence
-     *
-     * @Assert\Type(LsDefLicence::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefLicence::class)]
+    #[Assert\NotNull]
     private $licence;
 
     public function __construct(LsDefLicence $licence)

--- a/core/src/Command/Framework/DeleteSubjectCommand.php
+++ b/core/src/Command/Framework/DeleteSubjectCommand.php
@@ -10,10 +10,9 @@ class DeleteSubjectCommand extends BaseCommand
 {
     /**
      * @var LsDefSubject
-     *
-     * @Assert\Type(LsDefSubject::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDefSubject::class)]
+    #[Assert\NotNull]
     private $subject;
 
     public function __construct(LsDefSubject $subject)

--- a/core/src/Command/Framework/DeriveDocumentCommand.php
+++ b/core/src/Command/Framework/DeriveDocumentCommand.php
@@ -10,10 +10,9 @@ class DeriveDocumentCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     /**

--- a/core/src/Command/Framework/LockDocumentCommand.php
+++ b/core/src/Command/Framework/LockDocumentCommand.php
@@ -11,10 +11,9 @@ class LockDocumentCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     /**

--- a/core/src/Command/Framework/LockItemCommand.php
+++ b/core/src/Command/Framework/LockItemCommand.php
@@ -11,10 +11,9 @@ class LockItemCommand extends BaseCommand
 {
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     private $item;
 
     /**

--- a/core/src/Command/Framework/RemoveChildCommand.php
+++ b/core/src/Command/Framework/RemoveChildCommand.php
@@ -10,18 +10,16 @@ class RemoveChildCommand extends BaseCommand
 {
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     private $parent;
 
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     private $child;
 
     /**

--- a/core/src/Command/Framework/UpdateDocumentCommand.php
+++ b/core/src/Command/Framework/UpdateDocumentCommand.php
@@ -10,10 +10,9 @@ class UpdateDocumentCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     public function __construct(LsDoc $doc)

--- a/core/src/Command/Framework/UpdateFrameworkCommand.php
+++ b/core/src/Command/Framework/UpdateFrameworkCommand.php
@@ -13,10 +13,9 @@ class UpdateFrameworkCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     /**

--- a/core/src/Command/Framework/UpdateTreeItemsCommand.php
+++ b/core/src/Command/Framework/UpdateTreeItemsCommand.php
@@ -11,18 +11,16 @@ class UpdateTreeItemsCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     /**
      * @var array
-     *
-     * @Assert\Type("array")
-     * @Assert\NotNull()
      */
+    #[Assert\Type('array')]
+    #[Assert\NotNull]
     private $items;
 
     /**
@@ -60,9 +58,7 @@ class UpdateTreeItemsCommand extends BaseCommand
         return $this->rv;
     }
 
-    /**
-     * @Assert\Callback()
-     */
+    #[Assert\Callback]
     public function validate(ExecutionContextInterface $context, $payload): void
     {
         foreach ($this->items as $itemId => $updates) {

--- a/core/src/Command/Import/ImportAsnFromUrlCommand.php
+++ b/core/src/Command/Import/ImportAsnFromUrlCommand.php
@@ -10,10 +10,9 @@ class ImportAsnFromUrlCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $asnIdOrUrl;
 
     /**

--- a/core/src/Command/Import/ImportCaseJsonCommand.php
+++ b/core/src/Command/Import/ImportCaseJsonCommand.php
@@ -11,9 +11,8 @@ class ImportCaseJsonCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
      */
+    #[Assert\NotNull]
     private $caseJson;
 
     /**

--- a/core/src/Command/Import/ImportExcelFileCommand.php
+++ b/core/src/Command/Import/ImportExcelFileCommand.php
@@ -10,10 +10,9 @@ class ImportExcelFileCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $excelFilePath;
 
     /**

--- a/core/src/Command/Import/ImportGenericCsvCommand.php
+++ b/core/src/Command/Import/ImportGenericCsvCommand.php
@@ -10,10 +10,9 @@ class ImportGenericCsvCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $filePath;
 
     /**

--- a/core/src/Command/User/AddFrameworkUserAclCommand.php
+++ b/core/src/Command/User/AddFrameworkUserAclCommand.php
@@ -10,10 +10,9 @@ class AddFrameworkUserAclCommand extends BaseCommand
 {
     /**
      * @var AddAclUserDTO
-     *
-     * @Assert\Type(AddAclUserDTO::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(AddAclUserDTO::class)]
+    #[Assert\NotNull]
     private $dto;
 
     public function __construct(AddAclUserDTO $dto)

--- a/core/src/Command/User/AddOrganizationByNameCommand.php
+++ b/core/src/Command/User/AddOrganizationByNameCommand.php
@@ -9,10 +9,9 @@ class AddOrganizationByNameCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $organizationName;
 
     public function __construct(string $organizationName)

--- a/core/src/Command/User/AddUserByNameCommand.php
+++ b/core/src/Command/User/AddUserByNameCommand.php
@@ -10,17 +10,15 @@ class AddUserByNameCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $userName;
 
     /**
      * @var Organization
-     *
-     * @Assert\NotNull()
      */
+    #[Assert\NotNull]
     private $organization;
 
     /**

--- a/core/src/Command/User/AddUserCommand.php
+++ b/core/src/Command/User/AddUserCommand.php
@@ -9,15 +9,9 @@ class AddUserCommand extends UserCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\Length(
-     *     min=8,
-     *     max=4096,
-     *     minMessage="Password must be at least {{ limit }} characters long",
-     *     maxMessage="Password cannot be longer than {{ limit }} characters"
-     * )
      */
+    #[Assert\NotNull]
+    #[Assert\Length(min: 8, max: 4096, minMessage: 'Password must be at least {{ limit }} characters long', maxMessage: 'Password cannot be longer than {{ limit }} characters')]
     private $encryptedPassword;
 
     public function __construct(User $user, string $encryptedPassword)

--- a/core/src/Command/User/AddUserRoleCommand.php
+++ b/core/src/Command/User/AddUserRoleCommand.php
@@ -9,18 +9,16 @@ class AddUserRoleCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $username;
 
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $role;
 
     public function __construct(string $username, string $role)

--- a/core/src/Command/User/DeleteFrameworkAclCommand.php
+++ b/core/src/Command/User/DeleteFrameworkAclCommand.php
@@ -11,18 +11,16 @@ class DeleteFrameworkAclCommand extends BaseCommand
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     private $doc;
 
     /**
      * @var User
-     *
-     * @Assert\Type(User::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(User::class)]
+    #[Assert\NotNull]
     private $user;
 
     public function __construct(LsDoc $doc, User $user)

--- a/core/src/Command/User/OrganizationCommand.php
+++ b/core/src/Command/User/OrganizationCommand.php
@@ -10,10 +10,9 @@ abstract class OrganizationCommand extends BaseCommand
 {
     /**
      * @var Organization
-     *
-     * @Assert\Type(Organization::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(Organization::class)]
+    #[Assert\NotNull]
     private $organization;
 
     public function __construct(Organization $organization)

--- a/core/src/Command/User/RemoveUserRoleCommand.php
+++ b/core/src/Command/User/RemoveUserRoleCommand.php
@@ -9,18 +9,16 @@ class RemoveUserRoleCommand extends BaseCommand
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $username;
 
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private $role;
 
     public function __construct(string $username, string $role)

--- a/core/src/Command/User/SetUserPasswordCommand.php
+++ b/core/src/Command/User/SetUserPasswordCommand.php
@@ -7,10 +7,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class SetUserPasswordCommand extends BaseCommand
 {
-    /**
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private string $username;
 
     private ?string $plainPassword;

--- a/core/src/Command/User/UserCommand.php
+++ b/core/src/Command/User/UserCommand.php
@@ -10,10 +10,9 @@ abstract class UserCommand extends BaseCommand
 {
     /**
      * @var User
-     *
-     * @Assert\Type(User::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(User::class)]
+    #[Assert\NotNull]
     private $user;
 
     public function __construct(User $user)

--- a/core/src/Console/Framework/CopyDocumentToItemCommand.php
+++ b/core/src/Console/Framework/CopyDocumentToItemCommand.php
@@ -15,11 +15,11 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class CopyDocumentToItemCommand extends BaseDoctrineCommand
 {
+    protected static $defaultName = 'cfpackage:duplicate';
+
     protected function configure()
     {
-        $this
-            ->setName('cfpackage:duplicate')
-            ->setDescription('Copy a package to an item in a framework')
+        $this->setDescription('Copy a package to an item in a framework')
             ->addArgument('from', InputArgument::REQUIRED, 'Id of package to duplicate')
             ->addArgument('to', InputArgument::REQUIRED, 'Id of package to copy into')
         ;

--- a/core/src/Console/User/OrgAddCommand.php
+++ b/core/src/Console/User/OrgAddCommand.php
@@ -14,11 +14,11 @@ use Symfony\Component\Console\Question\Question;
 
 class OrgAddCommand extends BaseDoctrineCommand
 {
+    protected static $defaultName = 'salt:org:add';
+
     protected function configure(): void
     {
-        $this
-            ->setName('salt:org:add')
-            ->setDescription('Add an organization')
+        $this->setDescription('Add an organization')
             ->addArgument('org', InputArgument::REQUIRED, 'Organization name for the new user')
         ;
     }

--- a/core/src/Console/User/UserAddCommand.php
+++ b/core/src/Console/User/UserAddCommand.php
@@ -17,11 +17,11 @@ use Symfony\Component\Console\Question\Question;
 
 class UserAddCommand extends BaseDoctrineCommand
 {
+    protected static $defaultName = 'salt:user:add';
+
     protected function configure(): void
     {
-        $this
-            ->setName('salt:user:add')
-            ->setDescription('Add a local user')
+        $this->setDescription('Add a local user')
             ->addArgument('username', InputArgument::REQUIRED, 'Email address or username of the new user')
             ->addArgument('org', InputArgument::REQUIRED, 'Organization name for the new user')
             ->addOption('password', 'p', InputOption::VALUE_REQUIRED, 'Initial password for the new user')

--- a/core/src/Console/User/UserAddRoleCommand.php
+++ b/core/src/Console/User/UserAddRoleCommand.php
@@ -11,11 +11,11 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class UserAddRoleCommand extends UserRoleCommand
 {
+    protected static $defaultName = 'salt:user:add-role';
+
     protected function configure(): void
     {
-        $this
-            ->setName('salt:user:add-role')
-            ->setDescription('Add a role to a local user')
+        $this->setDescription('Add a role to a local user')
             ->addArgument('username', InputArgument::REQUIRED, 'Email address or username of the user to change')
             ->addArgument('role', InputArgument::REQUIRED, 'Role to give the user (editor, admin, super-user)')
         ;

--- a/core/src/Console/User/UserRemoveRoleCommand.php
+++ b/core/src/Console/User/UserRemoveRoleCommand.php
@@ -11,11 +11,11 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 
 class UserRemoveRoleCommand extends UserRoleCommand
 {
+    protected static $defaultName = 'salt:user:remove-role';
+
     protected function configure(): void
     {
-        $this
-            ->setName('salt:user:remove-role')
-            ->setDescription('Remove a role from a local user')
+        $this->setDescription('Remove a role from a local user')
             ->addArgument('username', InputArgument::REQUIRED, 'Email address or username of the user to change')
             ->addArgument('role', InputArgument::REQUIRED, 'Role to remove from the user (editor, admin, super-user)')
         ;

--- a/core/src/Console/User/UserSetPasswordCommand.php
+++ b/core/src/Console/User/UserSetPasswordCommand.php
@@ -13,11 +13,11 @@ use Symfony\Component\Console\Question\Question;
 
 class UserSetPasswordCommand extends BaseDispatchingCommand
 {
+    protected static $defaultName = 'salt:user:set-password';
+
     protected function configure()
     {
-        $this
-            ->setName('salt:user:set-password')
-            ->setDescription('Set the password for a local user')
+        $this->setDescription('Set the password for a local user')
             ->addArgument('username', InputArgument::REQUIRED, 'Email address or username of the user to change')
             ->addArgument('password', InputArgument::OPTIONAL, 'New password for the user')
         ;

--- a/core/src/Controller/Api/CaseDocController.php
+++ b/core/src/Controller/Api/CaseDocController.php
@@ -8,9 +8,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class CaseDocController extends AbstractController
 {
-    /**
-     * @Route("/api/doc", methods={"GET"}, name="case_swagger_doc")
-     */
+    #[Route(path: '/api/doc', methods: ['GET'], name: 'case_swagger_doc')]
     public function caseSwaggerDocAction(): Response
     {
         return $this->render('api/case_doc/case_swagger_doc.html.twig');

--- a/core/src/Controller/Api/CaseV1P0Controller.php
+++ b/core/src/Controller/Api/CaseV1P0Controller.php
@@ -19,9 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Serializer\SerializerInterface;
 
-/**
- * @Route("/ims/case/v1p0")
- */
+#[Route(path: '/ims/case/v1p0')]
 class CaseV1P0Controller extends AbstractController
 {
     use LoggerTrait;
@@ -33,9 +31,7 @@ class CaseV1P0Controller extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/CFDocuments.{_format}", name="api_v1p0_cfdocuments", methods={"GET"}, defaults={"_format"="json"})
-     */
+    #[Route(path: '/CFDocuments.{_format}', name: 'api_v1p0_cfdocuments', methods: ['GET'], defaults: ['_format' => 'json'])]
     public function getPublicCfDocumentsAction(Request $request, LsDocRepository $docRepository): Response
     {
         $limit = (int) $request->query->get('limit', '100');
@@ -99,9 +95,9 @@ class CaseV1P0Controller extends AbstractController
     }
 
     /**
-     * @Route("/CFPackages/{id}.{_format}", name="api_v1p0_cfpackage", methods={"GET"}, defaults={"_format"="json"})
      * @Entity("obj", expr="repository.findOneByIdentifier(id)")
      */
+    #[Route(path: '/CFPackages/{id}.{_format}', name: 'api_v1p0_cfpackage', methods: ['GET'], defaults: ['_format' => 'json'])]
     public function getCfPackageAction(Request $request, LsDoc $obj): Response
     {
         $id = $obj->getIdentifier();
@@ -133,10 +129,10 @@ class CaseV1P0Controller extends AbstractController
     }
 
     /**
-     * @Route("/CFItemAssociations/{id}.{_format}", name="api_v1p0_cfitemassociations", methods={"GET"}, defaults={"_format"="json"})
-     * @Route("/CFItems/{id}/associations.{_format}", name="api_v1p0_cfitemassociations2", methods={"GET"}, defaults={"_format"="json"})
      * @Entity("obj", expr="repository.findOneByIdentifier(id)")
      */
+    #[Route(path: '/CFItemAssociations/{id}.{_format}', name: 'api_v1p0_cfitemassociations', methods: ['GET'], defaults: ['_format' => 'json'])]
+    #[Route(path: '/CFItems/{id}/associations.{_format}', name: 'api_v1p0_cfitemassociations2', methods: ['GET'], defaults: ['_format' => 'json'])]
     public function getCfItemAssociationsAction(Request $request, LsItem $obj, LsAssociationRepository $associationRepository): Response
     {
         $item = $obj;
@@ -199,16 +195,14 @@ class CaseV1P0Controller extends AbstractController
         return $response;
     }
 
-    /**
-     * @Route("/CFAssociationGroupings/{id}.{_format}", name="api_v1p0_cfassociationgrouping", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsDefAssociationGrouping", "_format"="json"})
-     * @Route("/CFAssociations/{id}.{_format}", name="api_v1p0_cfassociation", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsAssociation", "_format"="json"})
-     * @Route("/CFDocuments/{id}.{_format}", name="api_v1p0_cfdocument", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsDoc", "_format"="json"})
-     * @Route("/CFItems/{id}.{_format}", name="api_v1p0_cfitem", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsItem", "_format"="json"})
-     * @Route("/CFLicenses/{id}.{_format}", name="api_v1p0_cflicense", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsDefLicence", "_format"="json"})
-     * @Route("/CFRubrics/{id}.{_format}", name="api_v1p0_cfrubric", methods={"GET"}, defaults={"class"="App\Entity\Framework\CfRubric", "_format"="json"})
-     * @Route("/CFRubricCriteria/{id}.{_format}", name="api_v1p0_cfrubriccriterion", methods={"GET"}, defaults={"class"="App\Entity\Framework\CfRubricCriterion", "_format"="json"})
-     * @Route("/CFRubricCriterionLevels/{id}.{_format}", name="api_v1p0_cfrubriccriterionlevel", methods={"GET"}, defaults={"class"="App\Entity\Framework\CfRubricCriterionLevel", "_format"="json"})
-     */
+    #[Route(path: '/CFAssociationGroupings/{id}.{_format}', name: 'api_v1p0_cfassociationgrouping', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefAssociationGrouping', '_format' => 'json'])]
+    #[Route(path: '/CFAssociations/{id}.{_format}', name: 'api_v1p0_cfassociation', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsAssociation', '_format' => 'json'])]
+    #[Route(path: '/CFDocuments/{id}.{_format}', name: 'api_v1p0_cfdocument', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDoc', '_format' => 'json'])]
+    #[Route(path: '/CFItems/{id}.{_format}', name: 'api_v1p0_cfitem', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsItem', '_format' => 'json'])]
+    #[Route(path: '/CFLicenses/{id}.{_format}', name: 'api_v1p0_cflicense', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefLicence', '_format' => 'json'])]
+    #[Route(path: '/CFRubrics/{id}.{_format}', name: 'api_v1p0_cfrubric', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\CfRubric', '_format' => 'json'])]
+    #[Route(path: '/CFRubricCriteria/{id}.{_format}', name: 'api_v1p0_cfrubriccriterion', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\CfRubricCriterion', '_format' => 'json'])]
+    #[Route(path: '/CFRubricCriterionLevels/{id}.{_format}', name: 'api_v1p0_cfrubriccriterionlevel', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\CfRubricCriterionLevel', '_format' => 'json'])]
     public function getObjectAction(Request $request, LsDocRepository $repo, string $class, string $id): Response
     {
         $obj = $repo->apiFindOneByClassIdentifier(['class' => $class, 'id' => $id]);
@@ -216,11 +210,9 @@ class CaseV1P0Controller extends AbstractController
         return $this->generateObjectResponse($request, $obj);
     }
 
-    /**
-     * @Route("/CFConcepts/{id}.{_format}", name="api_v1p0_cfconcept", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsDefConcept", "_format"="json"})
-     * @Route("/CFItemTypes/{id}.{_format}", name="api_v1p0_cfitemtype", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsDefItemType", "_format"="json"})
-     * @Route("/CFSubjects/{id}.{_format}", name="api_v1p0_cfsubject", methods={"GET"}, defaults={"class"="App\Entity\Framework\LsDefSubject", "_format"="json"})
-     */
+    #[Route(path: '/CFConcepts/{id}.{_format}', name: 'api_v1p0_cfconcept', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefConcept', '_format' => 'json'])]
+    #[Route(path: '/CFItemTypes/{id}.{_format}', name: 'api_v1p0_cfitemtype', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefItemType', '_format' => 'json'])]
+    #[Route(path: '/CFSubjects/{id}.{_format}', name: 'api_v1p0_cfsubject', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefSubject', '_format' => 'json'])]
     public function getObjectCollectionAction(Request $request, LsDocRepository $repo, string $class, string $id): Response
     {
         $obj = $repo->apiFindOneByClassIdentifier(['class' => $class, 'id' => $id]);

--- a/core/src/Controller/Api/CaseV1P0Controller.php
+++ b/core/src/Controller/Api/CaseV1P0Controller.php
@@ -242,7 +242,7 @@ class CaseV1P0Controller extends AbstractController
      */
     protected function generateObjectResponse(Request $request, CaseApiInterface $obj): Response
     {
-        $this->info('CASE API: Returned object', ['type' => get_class($obj), 'id' => $obj->getIdentifier()]);
+        $this->info('CASE API: Returned object', ['type' => $obj::class, 'id' => $obj->getIdentifier()]);
 
         $response = $this->generateBaseResponse($obj->getUpdatedAt());
 
@@ -250,7 +250,7 @@ class CaseV1P0Controller extends AbstractController
             return $response;
         }
 
-        $className = substr(strrchr(get_class($obj), '\\'), 1);
+        $className = substr(strrchr($obj::class, '\\'), 1);
         $response->setContent(
             $this->serializer->serialize($obj, 'json', [
                 'groups' => ['default', $className],
@@ -266,7 +266,7 @@ class CaseV1P0Controller extends AbstractController
      */
     protected function generateObjectCollectionResponse(Request $request, CaseApiInterface $obj): Response
     {
-        $this->info('CASE API: Returned object', ['type' => get_class($obj), 'id' => $obj->getIdentifier()]);
+        $this->info('CASE API: Returned object', ['type' => $obj::class, 'id' => $obj->getIdentifier()]);
 
         $response = $this->generateBaseResponse(new \DateTime());
 
@@ -276,7 +276,7 @@ class CaseV1P0Controller extends AbstractController
 
         $collection = explode('/', $request->getPathInfo())[4];
 
-        $className = substr(strrchr(get_class($obj), '\\'), 1);
+        $className = substr(strrchr($obj::class, '\\'), 1);
         $response->setContent(
             $this->serializer->serialize([$collection => [$obj]], 'json', [
                 'groups' => ['default', $className],

--- a/core/src/Controller/Api/CaseV1P0Controller.php
+++ b/core/src/Controller/Api/CaseV1P0Controller.php
@@ -4,6 +4,15 @@ namespace App\Controller\Api;
 
 use App\Entity\ChangeEntry;
 use App\Entity\Framework\CaseApiInterface;
+use App\Entity\Framework\CfRubric;
+use App\Entity\Framework\CfRubricCriterion;
+use App\Entity\Framework\CfRubricCriterionLevel;
+use App\Entity\Framework\LsAssociation;
+use App\Entity\Framework\LsDefAssociationGrouping;
+use App\Entity\Framework\LsDefConcept;
+use App\Entity\Framework\LsDefItemType;
+use App\Entity\Framework\LsDefLicence;
+use App\Entity\Framework\LsDefSubject;
 use App\Entity\Framework\LsDoc;
 use App\Entity\Framework\LsItem;
 use App\Repository\ChangeEntryRepository;
@@ -195,14 +204,14 @@ class CaseV1P0Controller extends AbstractController
         return $response;
     }
 
-    #[Route(path: '/CFAssociationGroupings/{id}.{_format}', name: 'api_v1p0_cfassociationgrouping', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefAssociationGrouping', '_format' => 'json'])]
-    #[Route(path: '/CFAssociations/{id}.{_format}', name: 'api_v1p0_cfassociation', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsAssociation', '_format' => 'json'])]
-    #[Route(path: '/CFDocuments/{id}.{_format}', name: 'api_v1p0_cfdocument', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDoc', '_format' => 'json'])]
-    #[Route(path: '/CFItems/{id}.{_format}', name: 'api_v1p0_cfitem', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsItem', '_format' => 'json'])]
-    #[Route(path: '/CFLicenses/{id}.{_format}', name: 'api_v1p0_cflicense', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefLicence', '_format' => 'json'])]
-    #[Route(path: '/CFRubrics/{id}.{_format}', name: 'api_v1p0_cfrubric', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\CfRubric', '_format' => 'json'])]
-    #[Route(path: '/CFRubricCriteria/{id}.{_format}', name: 'api_v1p0_cfrubriccriterion', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\CfRubricCriterion', '_format' => 'json'])]
-    #[Route(path: '/CFRubricCriterionLevels/{id}.{_format}', name: 'api_v1p0_cfrubriccriterionlevel', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\CfRubricCriterionLevel', '_format' => 'json'])]
+    #[Route(path: '/CFAssociationGroupings/{id}.{_format}', name: 'api_v1p0_cfassociationgrouping', methods: ['GET'], defaults: ['class' => LsDefAssociationGrouping::class, '_format' => 'json'])]
+    #[Route(path: '/CFAssociations/{id}.{_format}', name: 'api_v1p0_cfassociation', methods: ['GET'], defaults: ['class' => LsAssociation::class, '_format' => 'json'])]
+    #[Route(path: '/CFDocuments/{id}.{_format}', name: 'api_v1p0_cfdocument', methods: ['GET'], defaults: ['class' => LsDoc::class, '_format' => 'json'])]
+    #[Route(path: '/CFItems/{id}.{_format}', name: 'api_v1p0_cfitem', methods: ['GET'], defaults: ['class' => LsItem::class, '_format' => 'json'])]
+    #[Route(path: '/CFLicenses/{id}.{_format}', name: 'api_v1p0_cflicense', methods: ['GET'], defaults: ['class' => LsDefLicence::class, '_format' => 'json'])]
+    #[Route(path: '/CFRubrics/{id}.{_format}', name: 'api_v1p0_cfrubric', methods: ['GET'], defaults: ['class' => CfRubric::class, '_format' => 'json'])]
+    #[Route(path: '/CFRubricCriteria/{id}.{_format}', name: 'api_v1p0_cfrubriccriterion', methods: ['GET'], defaults: ['class' => CfRubricCriterion::class, '_format' => 'json'])]
+    #[Route(path: '/CFRubricCriterionLevels/{id}.{_format}', name: 'api_v1p0_cfrubriccriterionlevel', methods: ['GET'], defaults: ['class' => CfRubricCriterionLevel::class, '_format' => 'json'])]
     public function getObjectAction(Request $request, LsDocRepository $repo, string $class, string $id): Response
     {
         $obj = $repo->apiFindOneByClassIdentifier(['class' => $class, 'id' => $id]);
@@ -210,9 +219,9 @@ class CaseV1P0Controller extends AbstractController
         return $this->generateObjectResponse($request, $obj);
     }
 
-    #[Route(path: '/CFConcepts/{id}.{_format}', name: 'api_v1p0_cfconcept', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefConcept', '_format' => 'json'])]
-    #[Route(path: '/CFItemTypes/{id}.{_format}', name: 'api_v1p0_cfitemtype', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefItemType', '_format' => 'json'])]
-    #[Route(path: '/CFSubjects/{id}.{_format}', name: 'api_v1p0_cfsubject', methods: ['GET'], defaults: ['class' => 'App\Entity\Framework\LsDefSubject', '_format' => 'json'])]
+    #[Route(path: '/CFConcepts/{id}.{_format}', name: 'api_v1p0_cfconcept', methods: ['GET'], defaults: ['class' => LsDefConcept::class, '_format' => 'json'])]
+    #[Route(path: '/CFItemTypes/{id}.{_format}', name: 'api_v1p0_cfitemtype', methods: ['GET'], defaults: ['class' => LsDefItemType::class, '_format' => 'json'])]
+    #[Route(path: '/CFSubjects/{id}.{_format}', name: 'api_v1p0_cfsubject', methods: ['GET'], defaults: ['class' => LsDefSubject::class, '_format' => 'json'])]
     public function getObjectCollectionAction(Request $request, LsDocRepository $repo, string $class, string $id): Response
     {
         $obj = $repo->apiFindOneByClassIdentifier(['class' => $class, 'id' => $id]);

--- a/core/src/Controller/Api/LorSupportController.php
+++ b/core/src/Controller/Api/LorSupportController.php
@@ -12,9 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/api/v1/lor")
- */
+#[Route(path: '/api/v1/lor')]
 class LorSupportController extends AbstractController
 {
     use LoggerTrait;
@@ -26,9 +24,7 @@ class LorSupportController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/creators", methods={"GET"}, name="api_get_creators")
-     */
+    #[Route(path: '/creators', methods: ['GET'], name: 'api_get_creators')]
     public function getCreators(Request $request): JsonResponse
     {
         // Get all creators for public documents
@@ -59,9 +55,7 @@ class LorSupportController extends AbstractController
         return $response;
     }
 
-    /**
-     * @Route("/frameworksByCreator/{creator}", methods={"GET"}, name="api_get_frameworks_by_creator")
-     */
+    #[Route(path: '/frameworksByCreator/{creator}', methods: ['GET'], name: 'api_get_frameworks_by_creator')]
     public function getFrameworksByCreator(Request $request, string $creator): JsonResponse
     {
         $results = $this->docRepository->findNonPrivateByCreator(urldecode($creator));
@@ -95,9 +89,7 @@ class LorSupportController extends AbstractController
         return $response;
     }
 
-    /**
-     * @Route("/exactMatchIdentifiers/{identifier}", methods={"GET"}, name="api_get_exact_matches")
-     */
+    #[Route(path: '/exactMatchIdentifiers/{identifier}', methods: ['GET'], name: 'api_get_exact_matches')]
     public function getMatches(Request $request, string $identifier): JsonResponse
     {
         $results = $this->itemRepository->findExactMatches($identifier);

--- a/core/src/Controller/Api/LorSupportController.php
+++ b/core/src/Controller/Api/LorSupportController.php
@@ -80,9 +80,7 @@ class LorSupportController extends AbstractController
             return $response;
         }
 
-        usort($docs, function ($a, $b) {
-            return strcmp($a['title'], $b['title']);
-        });
+        usort($docs, fn ($a, $b) => strcmp($a['title'], $b['title']));
 
         $response->setData($docs);
 

--- a/core/src/Controller/AsnImportController.php
+++ b/core/src/Controller/AsnImportController.php
@@ -23,10 +23,9 @@ class AsnImportController extends AbstractController
     use CommandDispatcherTrait;
 
     /**
-     * @Route("/cf/asn/import", name="import_from_asn")
-     *
      * @return JsonResponse
      */
+    #[Route(path: '/cf/asn/import', name: 'import_from_asn')]
     public function importAsnAction(Request $request, UserInterface $user): Response
     {
         if (!$user instanceof User) {

--- a/core/src/Controller/CaseImportController.php
+++ b/core/src/Controller/CaseImportController.php
@@ -22,9 +22,9 @@ class CaseImportController extends AbstractController
     use CommandDispatcherTrait;
 
     /**
-     * @Route("/salt/case/import", name="import_case_file")
      * @Security("is_granted('create', 'lsdoc')")
      */
+    #[Route(path: '/salt/case/import', name: 'import_case_file')]
     public function importAction(Request $request, UserInterface $user): JsonResponse
     {
         if (!$user instanceof User) {
@@ -42,9 +42,9 @@ class CaseImportController extends AbstractController
     }
 
     /**
-     * @Route("/salt/case/importRemote", name="import_case_file_remote")
      * @Security("is_granted('create', 'lsdoc')")
      */
+    #[Route(path: '/salt/case/importRemote', name: 'import_case_file_remote')]
     public function importRemoteAction(Request $request, UserInterface $user): Response
     {
         if (!$user instanceof User) {

--- a/core/src/Controller/Cms/ExportController.php
+++ b/core/src/Controller/Cms/ExportController.php
@@ -8,9 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/cms")
- */
+#[Route(path: '/cms')]
 class ExportController extends AbstractController
 {
     public function __construct(
@@ -20,9 +18,8 @@ class ExportController extends AbstractController
 
     /**
      * Generate JSON formatted for export to CMS.
-     *
-     * @Route("/cfdoc/{id}.{_format}", methods={"GET"}, name="lsdoc_api_view", requirements={"id"="\d+"})
      */
+    #[Route(path: '/cfdoc/{id}.{_format}', methods: ['GET'], name: 'lsdoc_api_view', requirements: ['id' => '\d+'])]
     public function exportAction(LsDoc $lsDoc, string $_format = 'json'): Response
     {
         $items = $this->managerRegistry->getRepository(LsDoc::class)->findAllChildrenArray($lsDoc);

--- a/core/src/Controller/CommentsController.php
+++ b/core/src/Controller/CommentsController.php
@@ -141,7 +141,7 @@ class CommentsController extends AbstractController
             $this->sendCommand($command);
 
             return $this->apiResponse($comment);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return $this->apiResponse('Item not found', 404);
         }
     }

--- a/core/src/Controller/CommentsController.php
+++ b/core/src/Controller/CommentsController.php
@@ -49,25 +49,24 @@ class CommentsController extends AbstractController
     }
 
     /**
-     * @Route("/comments/document/{id<\d+>}", name="create_doc_comment", methods={"POST"})
      * @Security("is_granted('comment')")
      */
+    #[Route(path: '/comments/document/{id<\d+>}', name: 'create_doc_comment', methods: ['POST'])]
     public function newDocCommentAction(Request $request, LsDoc $doc, UserInterface $user, BucketService $bucket): JsonResponse
     {
         return $this->addComment($request, 'document', $doc, $user, $bucket);
     }
 
     /**
-     * @Route("/comments/item/{id<\d+>}", name="create_item_comment", methods={"POST"})
      * @Security("is_granted('comment')")
      */
+    #[Route(path: '/comments/item/{id<\d+>}', name: 'create_item_comment', methods: ['POST'])]
     public function newItemCommentAction(Request $request, LsItem $item, UserInterface $user, BucketService $bucket): JsonResponse
     {
         return $this->addComment($request, 'item', $item, $user, $bucket);
     }
 
     /**
-     * @Route("/comments/{itemType<document|item>}/{itemId<\d+>}", name="get_comments", methods={"GET"})
      * @Entity("comments", class="App\Entity\Comment\Comment", expr="repository.findByTypeItem(itemType, itemId)")
      * @Security("is_granted('comment_view')")
      *
@@ -75,6 +74,7 @@ class CommentsController extends AbstractController
      *
      * @return mixed
      */
+    #[Route(path: '/comments/{itemType<document|item>}/{itemId<\d+>}', name: 'get_comments', methods: ['GET'])]
     public function listAction(array $comments, UserInterface $user = null)
     {
         if ($user instanceof User) {
@@ -87,9 +87,9 @@ class CommentsController extends AbstractController
     }
 
     /**
-     * @Route("/comments/{id}", methods={"PUT"})
      * @Security("is_granted('comment_update', comment)")
      */
+    #[Route(path: '/comments/{id}', methods: ['PUT'])]
     public function updateAction(Request $request, Comment $comment, UserInterface $user): JsonResponse
     {
         $command = new UpdateCommentCommand($comment, $request->request->get('content'));
@@ -99,9 +99,9 @@ class CommentsController extends AbstractController
     }
 
     /**
-     * @Route("/comments/delete/{id}", methods={"DELETE"})
      * @Security("is_granted('comment_delete', comment)")
      */
+    #[Route(path: '/comments/delete/{id}', methods: ['DELETE'])]
     public function deleteAction(Comment $comment, UserInterface $user): JsonResponse
     {
         $command = new DeleteCommentCommand($comment);
@@ -111,9 +111,9 @@ class CommentsController extends AbstractController
     }
 
     /**
-     * @Route("/comments/{id}/upvote", methods={"POST"})
      * @Security("is_granted('comment')")
      */
+    #[Route(path: '/comments/{id}/upvote', methods: ['POST'])]
     public function upvoteAction(Comment $comment, UserInterface $user = null): JsonResponse
     {
         if (!$user instanceof User) {
@@ -127,9 +127,9 @@ class CommentsController extends AbstractController
     }
 
     /**
-     * @Route("/comments/{id}/upvote", methods={"DELETE"})
      * @Security("is_granted('comment')")
      */
+    #[Route(path: '/comments/{id}/upvote', methods: ['DELETE'])]
     public function downvoteAction(Comment $comment, UserInterface $user): JsonResponse
     {
         if (!$user instanceof User) {
@@ -147,9 +147,9 @@ class CommentsController extends AbstractController
     }
 
     /**
-     * @Route("/salt/case/export_comment/{itemType}/{itemId}/comment.csv", name="export_comment_file")
      * @Security("is_granted('comment_view')")
      */
+    #[Route(path: '/salt/case/export_comment/{itemType}/{itemId}/comment.csv', name: 'export_comment_file')]
     public function exportCommentAction(string $itemType, int $itemId): Response
     {
         $response = new StreamedResponse();

--- a/core/src/Controller/DefaultController.php
+++ b/core/src/Controller/DefaultController.php
@@ -7,9 +7,7 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class DefaultController extends AbstractController
 {
-    /**
-     * @Route("/", name="salt_index")
-     */
+    #[Route(path: '/', name: 'salt_index')]
     public function indexAction()
     {
         return $this->redirectToRoute('lsdoc_index');

--- a/core/src/Controller/DocRevisionController.php
+++ b/core/src/Controller/DocRevisionController.php
@@ -20,9 +20,9 @@ class DocRevisionController extends AbstractController
     }
 
     /**
-     * @Route("/cfdoc/{id}/revisions/{offset}/{limit}", methods={"GET"}, requirements={"offset" = "\d+", "limit" = "\d+"}, defaults={"offset" = 0, "limit" = 0}, name="doc_revisions_json")
      * @Security("is_granted('edit', doc)")
      */
+    #[Route(path: '/cfdoc/{id}/revisions/{offset}/{limit}', methods: ['GET'], requirements: ['offset' => '\d+', 'limit' => '\d+'], defaults: ['offset' => 0, 'limit' => 0], name: 'doc_revisions_json')]
     public function listDocRevisionsAction(LsDoc $doc, int $offset, int $limit): Response
     {
         $response = new StreamedResponse();
@@ -52,9 +52,9 @@ class DocRevisionController extends AbstractController
     }
 
     /**
-     * @Route("/cfdoc/{id}/revisions/export", name="doc_revisions_csv", methods={"GET"})
      * @Security("is_granted('edit', doc)")
      */
+    #[Route(path: '/cfdoc/{id}/revisions/export', name: 'doc_revisions_csv', methods: ['GET'])]
     public function exportDocRevisions(LsDoc $doc): Response
     {
         $response = new StreamedResponse();

--- a/core/src/Controller/ExcelExportController.php
+++ b/core/src/Controller/ExcelExportController.php
@@ -25,9 +25,7 @@ class ExcelExportController extends AbstractController
         $this->excelExport = $excelExport;
     }
 
-    /**
-     * @Route("/cfdoc/{id}/excel", methods={"GET"}, name="export_excel_file")
-     */
+    #[Route(path: '/cfdoc/{id}/excel', methods: ['GET'], name: 'export_excel_file')]
     public function exportExcelAction(LsDoc $lsDoc): StreamedResponse
     {
         $title = preg_replace('/[^A-Za-z0-9]/', '_', $lsDoc->getTitle());

--- a/core/src/Controller/ExcelExportController.php
+++ b/core/src/Controller/ExcelExportController.php
@@ -5,7 +5,9 @@ namespace App\Controller;
 use App\Command\CommandDispatcherTrait;
 use App\Entity\Framework\LsDoc;
 use App\Service\ExcelExport;
+use PhpOffice\PhpSpreadsheet\IOFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -34,10 +36,10 @@ class ExcelExportController extends AbstractController
 
         return new StreamedResponse(
             function () use ($phpExcelObject) {
-                \PhpOffice\PhpSpreadsheet\IOFactory::createWriter($phpExcelObject, 'Xlsx')
+                IOFactory::createWriter($phpExcelObject, 'Xlsx')
                     ->save('php://output');
             },
-            200,
+            Response::HTTP_OK,
             [
                 'Content-Type' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
                 'Content-Disposition' => 'attachment; filename="'.$title.'.xlsx"',

--- a/core/src/Controller/ExcelImportController.php
+++ b/core/src/Controller/ExcelImportController.php
@@ -17,9 +17,9 @@ class ExcelImportController extends AbstractController
     use CommandDispatcherTrait;
 
     /**
-     * @Route("/salt/excel/import", methods={"POST"}, name="import_excel_file")
      * @Security("is_granted('create', 'lsdoc')")
      */
+    #[Route(path: '/salt/excel/import', methods: ['POST'], name: 'import_excel_file')]
     public function importExcelAction(Request $request, UserInterface $user): Response
     {
         if (!($user instanceof User)) {

--- a/core/src/Controller/Framework/AdditionalFieldController.php
+++ b/core/src/Controller/Framework/AdditionalFieldController.php
@@ -16,9 +16,9 @@ use Symfony\Component\Routing\Annotation\Route;
 /**
  * AdditionalField controller.
  *
- * @Route("/additionalfield")
  * @Security("is_granted('manage', 'additional_fields')")
  */
+#[Route(path: '/additionalfield')]
 class AdditionalFieldController extends AbstractController
 {
     private AdditionalFieldRepository $additionalFieldRepository;
@@ -32,9 +32,8 @@ class AdditionalFieldController extends AbstractController
 
     /**
      * List all AdditionalField entities.
-     *
-     * @Route("/", name="additional_field_index")
      */
+    #[Route(path: '/', name: 'additional_field_index')]
     public function index(): Response
     {
         return $this->render('framework/additional_field/index.html.twig', [
@@ -44,9 +43,8 @@ class AdditionalFieldController extends AbstractController
 
     /**
      * Create an AdditionalField entity.
-     *
-     * @Route("/new", name="additional_field_new")
      */
+    #[Route(path: '/new', name: 'additional_field_new')]
     public function create(Request $request): Response
     {
         $additionalField = new AdditionalField();
@@ -66,9 +64,8 @@ class AdditionalFieldController extends AbstractController
 
     /**
      * Show a AdditionalField entity.
-     *
-     * @Route("/{id}", name="additional_field_show")
      */
+    #[Route(path: '/{id}', name: 'additional_field_show')]
     public function show(AdditionalField $additionalField): Response
     {
         return $this->render('framework/additional_field/show.html.twig', [
@@ -78,9 +75,8 @@ class AdditionalFieldController extends AbstractController
 
     /**
      * Update an AdditionalField entity.
-     *
-     * @Route("/edit/{id}", name="additional_field_update")
      */
+    #[Route(path: '/edit/{id}', name: 'additional_field_update')]
     public function update(AdditionalField $additionalField, Request $request): Response
     {
         $form = $this->createForm(AdditionalFieldType::class, $additionalField);
@@ -98,9 +94,8 @@ class AdditionalFieldController extends AbstractController
 
     /**
      * Delete a AdditionalField entity.
-     *
-     * @Route("/delete/{id}", name="additional_field_delete")
      */
+    #[Route(path: '/delete/{id}', name: 'additional_field_delete')]
     public function delete(AdditionalField $additionalField): RedirectResponse
     {
         $this->entityManager->remove($additionalField);

--- a/core/src/Controller/Framework/CfPackageController.php
+++ b/core/src/Controller/Framework/CfPackageController.php
@@ -13,9 +13,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Class CfPackageController.
- *
- * @Route("/cfpackage")
  */
+#[Route(path: '/cfpackage')]
 class CfPackageController extends AbstractController
 {
     public function __construct(
@@ -26,10 +25,9 @@ class CfPackageController extends AbstractController
 
     /**
      * Export a CFPackage.
-     *
-     * @Route("/doc/{id}.{_format}", requirements={"_format"="(json|html|pdf|csv)"}, methods={"GET"}, defaults={"_format"="json"}, name="cfpackage_export")
-     * @Route("/doc/{id}/export.{_format}", requirements={"_format"="(json|html|pdf|csv)"}, methods={"GET"}, defaults={"_format"="json"}, name="cfpackage_export2")
      */
+    #[Route(path: '/doc/{id}.{_format}', requirements: ['_format' => '(json|html|pdf|csv)'], methods: ['GET'], defaults: ['_format' => 'json'], name: 'cfpackage_export')]
+    #[Route(path: '/doc/{id}/export.{_format}', requirements: ['_format' => '(json|html|pdf|csv)'], methods: ['GET'], defaults: ['_format' => 'json'], name: 'cfpackage_export2')]
     public function exportAction(Request $request, LsDoc $lsDoc, string $_format = 'json'): Response
     {
         if ('json' === $_format) {

--- a/core/src/Controller/Framework/CloneController.php
+++ b/core/src/Controller/Framework/CloneController.php
@@ -13,17 +13,16 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Copy controller.
- *
- * @Route("/clone")
  */
+#[Route(path: '/clone')]
 class CloneController extends AbstractController
 {
     use CommandDispatcherTrait;
 
     /**
-     * @Route("/framework/{id}", name="clone_framework", methods={"GET"})
      * @Security("is_granted('edit', lsDoc) and is_granted('create', 'lsdoc')")
      */
+    #[Route(path: '/framework/{id}', name: 'clone_framework', methods: ['GET'])]
     public function frameworkAction(Request $request, LsDoc $lsDoc): Response
     {
         $command = new CloneFrameworkCommand($lsDoc);

--- a/core/src/Controller/Framework/CopyController.php
+++ b/core/src/Controller/Framework/CopyController.php
@@ -14,9 +14,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Copy controller.
- *
- * @Route("/copy")
  */
+#[Route(path: '/copy')]
 class CopyController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -27,9 +26,9 @@ class CopyController extends AbstractController
     }
 
     /**
-     * @Route("/framework/{id}", name="copy_framework_content", methods={"POST"})
      * @Security("is_granted('view', lsDoc)")
      */
+    #[Route(path: '/framework/{id}', name: 'copy_framework_content', methods: ['POST'])]
     public function frameworkAction(Request $request, LsDoc $lsDoc): JsonResponse
     {
         $type = $request->request->get('type');

--- a/core/src/Controller/Framework/DocTreeController.php
+++ b/core/src/Controller/Framework/DocTreeController.php
@@ -557,7 +557,7 @@ class DocTreeController extends AbstractController
             }
 
             $content = $response->getContent();
-            $json = json_decode($content, true);
+            $json = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
             $lastModified = new \DateTime($json['CFDocument']['lastChangeDateTime'], new \DateTimeZone('UTC'));
 
             $response->setEtag(md5($lastModified->format('U.u').self::ETAG_SEED), true);
@@ -581,7 +581,7 @@ class DocTreeController extends AbstractController
 
     protected function addExternalDocumentToDoc(string $url, LsDoc $lsDoc, $document): void
     {
-        $doc = json_decode($document, false);
+        $doc = json_decode($document, false, 512, JSON_THROW_ON_ERROR);
         $title = $doc->CFDocument->title;
         $identifier = $doc->CFDocument->identifier;
 

--- a/core/src/Controller/Framework/DocTreeController.php
+++ b/core/src/Controller/Framework/DocTreeController.php
@@ -20,6 +20,7 @@ use App\Form\Type\LsDocListType;
 use App\Util\Compare;
 use Doctrine\Persistence\ManagerRegistry;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -282,7 +283,7 @@ class DocTreeController extends AbstractController
     }
 
     /**
-     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws GuzzleException
      */
     protected function exportExternalDocument(string $url, ?LsDoc $lsDoc = null): Response
     {
@@ -559,7 +560,7 @@ class DocTreeController extends AbstractController
         if (!empty($externalDocs[$identifier])) {
             // if we found it, load it, noting that we don't have to save a record of it in externalDocs (since it's already there)
             $response = $this->exportExternalDocument($externalDocs[$identifier]['url'], null);
-            if (200 !== $response->getStatusCode()) {
+            if (Response::HTTP_OK !== $response->getStatusCode()) {
                 return $response;
             }
 

--- a/core/src/Controller/Framework/DocTreeController.php
+++ b/core/src/Controller/Framework/DocTreeController.php
@@ -37,9 +37,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * Editor Tree controller.
- *
- * @Route("/cftree")
  */
+#[Route(path: '/cftree')]
 class DocTreeController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -57,13 +56,13 @@ class DocTreeController extends AbstractController
     }
 
     /**
-     * @Route("/doc/{slug}", name="doc_tree_view", methods={"GET"}, requirements={"slug"="[a-zA-Z0-9.-]+"}, defaults={"lsItemId"=null})
-     * @Route("/doc/{slug}/av", name="doc_tree_view_av", methods={"GET"}, requirements={"slug"="[a-zA-Z0-9.-]+"}, defaults={"lsItemId"=null})
-     * @Route("/doc/{slug}/lv", name="doc_tree_view_log", methods={"GET"}, requirements={"slug"="[a-zA-Z0-9.-]+"}, defaults={"lsItemId"=null})
-     * @Route("/doc/{slug}/{assocGroup}", name="doc_tree_view_ag", methods={"GET"}, requirements={"slug"="[a-zA-Z0-9.-]+"}, defaults={"lsItemId"=null})
      * @Entity("lsDoc", expr="repository.findOneBySlug(slug)")
      * @Template()
      */
+    #[Route(path: '/doc/{slug}', name: 'doc_tree_view', methods: ['GET'], requirements: ['slug' => '[a-zA-Z0-9.-]+'], defaults: ['lsItemId' => null])]
+    #[Route(path: '/doc/{slug}/av', name: 'doc_tree_view_av', methods: ['GET'], requirements: ['slug' => '[a-zA-Z0-9.-]+'], defaults: ['lsItemId' => null])]
+    #[Route(path: '/doc/{slug}/lv', name: 'doc_tree_view_log', methods: ['GET'], requirements: ['slug' => '[a-zA-Z0-9.-]+'], defaults: ['lsItemId' => null])]
+    #[Route(path: '/doc/{slug}/{assocGroup}', name: 'doc_tree_view_ag', methods: ['GET'], requirements: ['slug' => '[a-zA-Z0-9.-]+'], defaults: ['lsItemId' => null])]
     public function viewAction(LsDoc $lsDoc, AuthorizationCheckerInterface $authChecker, ?UserInterface $user = null, $lsItemId = null, $assocGroup = null): array
     {
         $em = $this->managerRegistry->getManager();
@@ -129,9 +128,7 @@ class DocTreeController extends AbstractController
         return $ret;
     }
 
-    /**
-     * @Route("/remote", name="doc_tree_remote_view", methods={"GET"})
-     */
+    #[Route(path: '/remote', name: 'doc_tree_remote_view', methods: ['GET'])]
     public function viewRemoteAction(): Response
     {
         $assocSubTypes = $this->managerRegistry->getRepository(AssociationSubtype::class)->findAll();
@@ -179,9 +176,8 @@ class DocTreeController extends AbstractController
 
     /**
      * Export a CFPackage in a special json format designed for efficiently loading the package's data to the OpenSALT doctree client.
-     *
-     * @Route("/docexport/{id}.json", name="doctree_cfpackage_export", methods={"GET"})
      */
+    #[Route(path: '/docexport/{id}.json', name: 'doctree_cfpackage_export', methods: ['GET'])]
     public function exportAction(Request $request, LsDoc $lsDoc): JsonResponse
     {
         $response = new JsonResponse();
@@ -252,11 +248,10 @@ class DocTreeController extends AbstractController
     /**
      * Retrieve a CFPackage from the given document identifier, then use exportAction to export it.
      *
-     * @Route("/retrievedocument/{id}", name="doctree_retrieve_document", methods={"GET"})
-     * @Route("/retrievedocument/url", name="doctree_retrieve_document_by_url", methods={"GET"}, defaults={"id"=null})
-     *
      * @throws \Exception
      */
+    #[Route(path: '/retrievedocument/{id}', name: 'doctree_retrieve_document', methods: ['GET'])]
+    #[Route(path: '/retrievedocument/url', name: 'doctree_retrieve_document_by_url', methods: ['GET'], defaults: ['id' => null])]
     public function retrieveDocumentAction(Request $request, ?LsDoc $lsDoc = null): Response
     {
         ini_set('memory_limit', '1G');
@@ -375,31 +370,29 @@ class DocTreeController extends AbstractController
     }
 
     /**
-     * @Route("/item/{id}/details", name="doc_tree_item_details", methods={"GET"})
      * @Template()
      *
      * Note that this must come before viewItemAction for the url mapping to work properly.
      */
+    #[Route(path: '/item/{id}/details', name: 'doc_tree_item_details', methods: ['GET'])]
     public function treeItemDetailsAction(LsItem $lsItem): array
     {
         return ['lsItem' => $lsItem];
     }
 
-    /**
-     * @Route("/item/{id}.{_format}", name="doc_tree_item_view", methods={"GET"}, defaults={"_format"="html"})
-     * @Route("/item/{id}/{assocGroup}.{_format}", name="doc_tree_item_view_ag", methods={"GET"}, defaults={"_format"="html"})
-     */
+    #[Route(path: '/item/{id}.{_format}', name: 'doc_tree_item_view', methods: ['GET'], defaults: ['_format' => 'html'])]
+    #[Route(path: '/item/{id}/{assocGroup}.{_format}', name: 'doc_tree_item_view_ag', methods: ['GET'], defaults: ['_format' => 'html'])]
     public function viewItemAction(LsItem $lsItem, ?string $assocGroup = null, string $_format = 'html'): Response
     {
         return $this->forward('App\Controller\Framework\DocTreeController::viewAction', ['slug' => $lsItem->getLsDoc()->getId(), '_format' => 'html', 'lsItemId' => $lsItem->getid(), 'assocGroup' => $assocGroup]);
     }
 
     /**
-     * @Route("/render/{id}.{_format}", methods={"GET"}, defaults={"_format"="html"}, name="doctree_render_document")
      * @Template()
      *
      * PW: this is similar to the renderDocument function in the Editor directory, but different enough that I think it deserves a separate controller/view
      */
+    #[Route(path: '/render/{id}.{_format}', methods: ['GET'], defaults: ['_format' => 'html'], name: 'doctree_render_document')]
     public function renderDocumentAction(LsDoc $lsDoc, $_format = 'html'): array
     {
         $repo = $this->managerRegistry->getRepository(LsDoc::class);
@@ -441,11 +434,11 @@ class DocTreeController extends AbstractController
     /**
      * Deletes a LsItem entity, from the tree view.
      *
-     * @Route("/item/{id}/delete/{includingChildren}", methods={"POST"}, name="lsitem_tree_delete", defaults={"includingChildren" = 0})
      * @Security("is_granted('edit', lsItem)")
      *
      * @throws \InvalidArgumentException
      */
+    #[Route(path: '/item/{id}/delete/{includingChildren}', methods: ['POST'], name: 'lsitem_tree_delete', defaults: ['includingChildren' => 0])]
     public function deleteItemAction(Request $request, LsItem $lsItem, int $includingChildren = 0): Response
     {
         $ajax = false;
@@ -477,10 +470,10 @@ class DocTreeController extends AbstractController
      * If we do a copy, the service returns an array of trees with the copied lsItemIds.
      * For other operations, we return an empty array.
      *
-     * @Route("/doc/{id}/updateitems.{_format}", methods={"POST"}, name="doctree_update_items")
      * @Security("is_granted('edit', lsDoc)")
      * @Template()
      */
+    #[Route(path: '/doc/{id}/updateitems.{_format}', methods: ['POST'], name: 'doctree_update_items')]
     public function updateItemsAction(Request $request, LsDoc $lsDoc, string $_format = 'json'): array
     {
         /** @var array $lsItems */
@@ -508,10 +501,9 @@ class DocTreeController extends AbstractController
     /**
      * Deletes a LsDefAssociationGrouping entity, ajax/treeview version.
      *
-     * @Route("/assocgroup/{id}/delete", methods={"POST"}, name="lsdef_association_grouping_tree_delete")
-     *
      * @throws \InvalidArgumentException
      */
+    #[Route(path: '/assocgroup/{id}/delete', methods: ['POST'], name: 'lsdef_association_grouping_tree_delete')]
     public function deleteAssocGroupAction(Request $request, LsDefAssociationGrouping $associationGrouping): Response
     {
         $command = new DeleteAssociationGroupCommand($associationGrouping);

--- a/core/src/Controller/Framework/DocTreeController.php
+++ b/core/src/Controller/Framework/DocTreeController.php
@@ -364,7 +364,7 @@ class DocTreeController extends AbstractController
             $message = $e->getHandlerContext();
 
             throw new NotFoundHttpException($message['error']);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             throw new NotFoundHttpException('Document not found.');
         }
     }

--- a/core/src/Controller/Framework/EditorController.php
+++ b/core/src/Controller/Framework/EditorController.php
@@ -12,9 +12,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Editor controller.
- *
- * @Route("/cf")
  */
+#[Route(path: '/cf')]
 class EditorController extends AbstractController
 {
     public function __construct(
@@ -23,9 +22,9 @@ class EditorController extends AbstractController
     }
 
     /**
-     * @Route("/doc/{id}.{_format}", methods={"GET"}, defaults={"_format" = "html"}, name="editor_lsdoc")
      * @Template()
      */
+    #[Route(path: '/doc/{id}.{_format}', methods: ['GET'], defaults: ['_format' => 'html'], name: 'editor_lsdoc')]
     public function viewDocAction(LsDoc $lsDoc, string $_format = 'html')
     {
         if ('json' === $_format) {
@@ -36,9 +35,9 @@ class EditorController extends AbstractController
     }
 
     /**
-     * @Route("/item/{id}.{_format}", methods={"GET"}, defaults={"_format" = "html"}, name="editor_lsitem")
      * @Template()
      */
+    #[Route(path: '/item/{id}.{_format}', methods: ['GET'], defaults: ['_format' => 'html'], name: 'editor_lsitem')]
     public function viewItemAction(LsItem $lsItem, string $_format = 'html')
     {
         if ('json' === $_format) {
@@ -49,10 +48,10 @@ class EditorController extends AbstractController
     }
 
     /**
-     * @Route("/render/{id}.{_format}", methods={"GET"}, defaults={"highlight"=null, "_format"="html"}, name="editor_render_document_only")
-     * @Route("/render/{id}/{highlight}.{_format}", methods={"GET"}, defaults={"highlight"=null, "_format"="html"}, name="editor_render")
      * @Template()
      */
+    #[Route(path: '/render/{id}.{_format}', methods: ['GET'], defaults: ['highlight' => null, '_format' => 'html'], name: 'editor_render_document_only')]
+    #[Route(path: '/render/{id}/{highlight}.{_format}', methods: ['GET'], defaults: ['highlight' => null, '_format' => 'html'], name: 'editor_render')]
     public function renderDocumentAction(LsDoc $lsDoc, ?int $highlight = null, $_format = 'html'): array
     {
         $repo = $this->managerRegistry->getRepository(LsDoc::class);

--- a/core/src/Controller/Framework/LockController.php
+++ b/core/src/Controller/Framework/LockController.php
@@ -13,6 +13,7 @@ use App\Entity\User\User;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -50,7 +51,7 @@ class LockController extends AbstractController
             $command = new LockDocumentCommand($lsDoc, $user);
             $this->sendCommand($command);
         } catch (\Exception $e) {
-            return new JsonResponse($e->getMessage(), 422);
+            return new JsonResponse($e->getMessage(), Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
         return new JsonResponse('OK');
@@ -86,7 +87,7 @@ class LockController extends AbstractController
             $command = new LockItemCommand($item, $user);
             $this->sendCommand($command);
         } catch (\Exception $e) {
-            return new JsonResponse($e->getMessage(), 422);
+            return new JsonResponse($e->getMessage(), Response::HTTP_UNPROCESSABLE_ENTITY);
         }
 
         return new JsonResponse('OK');

--- a/core/src/Controller/Framework/LockController.php
+++ b/core/src/Controller/Framework/LockController.php
@@ -22,11 +22,11 @@ class LockController extends AbstractController
     use CommandDispatcherTrait;
 
     /**
-     * @Route("/cfdoc/{id}/unlock", methods={"POST"}, name="lsdoc_unlock")
      * @Security("is_granted('edit', lsDoc)")
      *
      * @param User $user
      */
+    #[Route(path: '/cfdoc/{id}/unlock', methods: ['POST'], name: 'lsdoc_unlock')]
     public function releaseDocLock(LsDoc $lsDoc, UserInterface $user): JsonResponse
     {
         try {
@@ -40,11 +40,11 @@ class LockController extends AbstractController
     }
 
     /**
-     * @Route("/cfdoc/{id}/lock", methods={"POST"}, name="lsdoc_lock")
      * @Security("is_granted('edit', lsDoc)")
      *
      * @param User $user
      */
+    #[Route(path: '/cfdoc/{id}/lock', methods: ['POST'], name: 'lsdoc_lock')]
     public function extendDocLock(LsDoc $lsDoc, UserInterface $user): JsonResponse
     {
         try {
@@ -58,11 +58,11 @@ class LockController extends AbstractController
     }
 
     /**
-     * @Route("/cfitem/{id}/unlock", methods={"POST"}, name="lsitem_unlock")
      * @Security("is_granted('edit', item)")
      *
      * @param User $user
      */
+    #[Route(path: '/cfitem/{id}/unlock', methods: ['POST'], name: 'lsitem_unlock')]
     public function releaseItemLock(LsItem $item, UserInterface $user): JsonResponse
     {
         try {
@@ -76,11 +76,11 @@ class LockController extends AbstractController
     }
 
     /**
-     * @Route("/cfitem/{id}/lock", methods={"POST"}, name="lsitem_lock")
      * @Security("is_granted('edit', item)")
      *
      * @param User $user
      */
+    #[Route(path: '/cfitem/{id}/lock', methods: ['POST'], name: 'lsitem_lock')]
     public function extendItemLock(LsItem $item, UserInterface $user): JsonResponse
     {
         try {

--- a/core/src/Controller/Framework/LsAssociationController.php
+++ b/core/src/Controller/Framework/LsAssociationController.php
@@ -27,9 +27,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * LsAssociation controller.
- *
- * @Route("/cfassociation")
  */
+#[Route(path: '/cfassociation')]
 class LsAssociationController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -42,9 +41,9 @@ class LsAssociationController extends AbstractController
     /**
      * Lists all LsAssociation entities.
      *
-     * @Route("/", name="lsassociation_index", methods={"GET"})
      * @Template()
      */
+    #[Route(path: '/', name: 'lsassociation_index', methods: ['GET'])]
     public function indexAction(): array
     {
         $em = $this->managerRegistry->getManager();
@@ -59,11 +58,11 @@ class LsAssociationController extends AbstractController
     /**
      * Creates a new LsAssociation entity.
      *
-     * @Route("/new/{sourceLsItem}", methods={"GET", "POST"}, name="lsassociation_new")
-     * @Route("/new/{sourceLsItem}/{assocGroup}", methods={"GET", "POST"}, name="lsassociation_new_ag")
      * @Template()
      * @Security("is_granted('add-association-to', sourceLsItem)")
      */
+    #[Route(path: '/new/{sourceLsItem}', methods: ['GET', 'POST'], name: 'lsassociation_new')]
+    #[Route(path: '/new/{sourceLsItem}/{assocGroup}', methods: ['GET', 'POST'], name: 'lsassociation_new_ag')]
     public function newAction(Request $request, ?LsItem $sourceLsItem = null, ?LsDefAssociationGrouping $assocGroup = null)
     {
         // @TODO: Add LsDoc of the new association for when adding via AJAX
@@ -117,9 +116,9 @@ class LsAssociationController extends AbstractController
     /**
      * Creates a new LsAssociation entity -- tree-view version, called via ajax.
      *
-     * @Route("/treenew/{lsDoc}", methods={"POST"}, name="lsassociation_tree_new")
      * @Security("is_granted('add-association-to', lsDoc)")
      */
+    #[Route(path: '/treenew/{lsDoc}', methods: ['POST'], name: 'lsassociation_tree_new')]
     public function treeNewAction(Request $request, LsDoc $lsDoc): Response
     {
         // type, origin['externalDoc', 'id', 'identifier'], dest['externalDoc', 'id', 'identifier'], assocGroup
@@ -159,11 +158,11 @@ class LsAssociationController extends AbstractController
     /**
      * Creates a new LsAssociation entity for an exemplar.
      *
-     * @Route("/treenewexemplar/{originLsItem}", methods={"GET", "POST"}, name="lsassociation_tree_new_exemplar")
      * @Security("is_granted('add-association-to', originLsItem)")
      *
      * @throws \InvalidArgumentException
      */
+    #[Route(path: '/treenewexemplar/{originLsItem}', methods: ['GET', 'POST'], name: 'lsassociation_tree_new_exemplar')]
     public function treeNewExemplarAction(Request $request, LsItem $originLsItem): Response
     {
         if (!$request->request->has('exemplarUrl')) {
@@ -196,9 +195,9 @@ class LsAssociationController extends AbstractController
     /**
      * Finds and displays a LsAssociation entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="lsassociation_show")
      * @Template()
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'lsassociation_show')]
     public function showAction(LsAssociation $lsAssociation): array
     {
         $deleteForm = $this->createDeleteForm($lsAssociation);
@@ -212,10 +211,10 @@ class LsAssociationController extends AbstractController
     /**
      * Displays a form to edit an existing LsAssociation entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsassociation_edit")
      * @Template()
      * @Security("is_granted('edit', lsAssociation)")
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsassociation_edit')]
     public function editAction(Request $request, LsAssociation $lsAssociation)
     {
         $deleteForm = $this->createDeleteForm($lsAssociation);
@@ -243,9 +242,9 @@ class LsAssociationController extends AbstractController
     /**
      * Deletes a LsAssociation entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsassociation_delete")
      * @Security("is_granted('edit', lsAssociation)")
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsassociation_delete')]
     public function deleteAction(Request $request, LsAssociation $lsAssociation): RedirectResponse
     {
         $form = $this->createDeleteForm($lsAssociation);
@@ -262,10 +261,10 @@ class LsAssociationController extends AbstractController
     /**
      * Remove a child LSItem.
      *
-     * @Route("/{id}/remove", methods={"POST"}, name="lsassociation_remove")
      * @Template()
      * @Security("is_granted('edit', lsAssociation)")
      */
+    #[Route(path: '/{id}/remove', methods: ['POST'], name: 'lsassociation_remove')]
     public function removeChildAction(LsAssociation $lsAssociation): array
     {
         $command = new DeleteAssociationCommand($lsAssociation);
@@ -277,9 +276,9 @@ class LsAssociationController extends AbstractController
     /**
      * Export an LsAssociation entity.
      *
-     * @Route("/{id}/export", methods={"GET"}, defaults={"_format"="json"}, name="lsassociation_export")
      * @Template()
      */
+    #[Route(path: '/{id}/export', methods: ['GET'], defaults: ['_format' => 'json'], name: 'lsassociation_export')]
     public function exportAction(LsAssociation $lsAssociation): array
     {
         return [

--- a/core/src/Controller/Framework/LsDefAssociationGroupingController.php
+++ b/core/src/Controller/Framework/LsDefAssociationGroupingController.php
@@ -14,6 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -113,7 +114,7 @@ class LsDefAssociationGroupingController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function editAction(Request $request, LsDefAssociationGrouping $associationGrouping)
     {
@@ -145,7 +146,7 @@ class LsDefAssociationGroupingController extends AbstractController
      * @Route("/{id}", methods={"DELETE"}, name="lsdef_association_grouping_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
     public function deleteAction(Request $request, LsDefAssociationGrouping $associationGrouping)
     {
@@ -165,7 +166,7 @@ class LsDefAssociationGroupingController extends AbstractController
      *
      * @param LsDefAssociationGrouping $associationGrouping The LsDefAssociationGrouping entity
      *
-     * @return \Symfony\Component\Form\FormInterface The form
+     * @return FormInterface The form
      */
     private function createDeleteForm(LsDefAssociationGrouping $associationGrouping): FormInterface
     {

--- a/core/src/Controller/Framework/LsDefAssociationGroupingController.php
+++ b/core/src/Controller/Framework/LsDefAssociationGroupingController.php
@@ -19,9 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/cfdef/association_grouping")
- */
+#[Route(path: '/cfdef/association_grouping')]
 class LsDefAssociationGroupingController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -34,9 +32,9 @@ class LsDefAssociationGroupingController extends AbstractController
     /**
      * Lists all LsDefAssociationGrouping entities.
      *
-     * @Route("/", methods={"GET"}, name="lsdef_association_grouping_index")
      * @Template()
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsdef_association_grouping_index')]
     public function indexAction(): array
     {
         $em = $this->managerRegistry->getManager();
@@ -51,10 +49,10 @@ class LsDefAssociationGroupingController extends AbstractController
     /**
      * Creates a new LsDefAssociationGrouping entity.
      *
-     * @Route("/new", methods={"GET", "POST"}, name="lsdef_association_grouping_new")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'lsdef_association_grouping_new')]
     public function newAction(Request $request): array|Response
     {
         $ajax = $request->isXmlHttpRequest();
@@ -92,11 +90,11 @@ class LsDefAssociationGroupingController extends AbstractController
     /**
      * Finds and displays a LsDefAssociationGrouping entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="lsdef_association_grouping_show")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'lsdef_association_grouping_show')]
     public function showAction(LsDefAssociationGrouping $associationGrouping)
     {
         $deleteForm = $this->createDeleteForm($associationGrouping);
@@ -110,12 +108,12 @@ class LsDefAssociationGroupingController extends AbstractController
     /**
      * Displays a form to edit an existing LsDefAssociationGrouping entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsdef_association_grouping_edit")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsdef_association_grouping_edit')]
     public function editAction(Request $request, LsDefAssociationGrouping $associationGrouping)
     {
         $deleteForm = $this->createDeleteForm($associationGrouping);
@@ -143,11 +141,11 @@ class LsDefAssociationGroupingController extends AbstractController
     /**
      * Deletes a LsDefAssociationGrouping entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsdef_association_grouping_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return RedirectResponse
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsdef_association_grouping_delete')]
     public function deleteAction(Request $request, LsDefAssociationGrouping $associationGrouping)
     {
         $form = $this->createDeleteForm($associationGrouping);

--- a/core/src/Controller/Framework/LsDefConceptController.php
+++ b/core/src/Controller/Framework/LsDefConceptController.php
@@ -21,9 +21,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * LsDefConcept controller.
- *
- * @Route("/cfdef/concept")
  */
+#[Route(path: '/cfdef/concept')]
 class LsDefConceptController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -36,11 +35,11 @@ class LsDefConceptController extends AbstractController
     /**
      * Lists all LsDefConcept entities.
      *
-     * @Route("/", methods={"GET"}, name="lsdef_concept_index")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsdef_concept_index')]
     public function indexAction()
     {
         $em = $this->managerRegistry->getManager();
@@ -55,12 +54,12 @@ class LsDefConceptController extends AbstractController
     /**
      * Creates a new LsDefConcept entity.
      *
-     * @Route("/new", methods={"GET", "POST"}, name="lsdef_concept_new")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'lsdef_concept_new')]
     public function newAction(Request $request)
     {
         $lsDefConcept = new LsDefConcept();
@@ -87,9 +86,9 @@ class LsDefConceptController extends AbstractController
     /**
      * Finds and displays a LsDefConcept entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="lsdef_concept_show")
      * @Template()
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'lsdef_concept_show')]
     public function showAction(LsDefConcept $lsDefConcept): array
     {
         $deleteForm = $this->createDeleteForm($lsDefConcept);
@@ -103,12 +102,12 @@ class LsDefConceptController extends AbstractController
     /**
      * Displays a form to edit an existing LsDefConcept entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsdef_concept_edit")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsdef_concept_edit')]
     public function editAction(Request $request, LsDefConcept $lsDefConcept)
     {
         $deleteForm = $this->createDeleteForm($lsDefConcept);
@@ -136,11 +135,11 @@ class LsDefConceptController extends AbstractController
     /**
      * Deletes a LsDefConcept entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsdef_concept_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return RedirectResponse
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsdef_concept_delete')]
     public function deleteAction(Request $request, LsDefConcept $lsDefConcept): Response
     {
         $form = $this->createDeleteForm($lsDefConcept);

--- a/core/src/Controller/Framework/LsDefConceptController.php
+++ b/core/src/Controller/Framework/LsDefConceptController.php
@@ -14,6 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -58,7 +59,7 @@ class LsDefConceptController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function newAction(Request $request)
     {
@@ -106,7 +107,7 @@ class LsDefConceptController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function editAction(Request $request, LsDefConcept $lsDefConcept)
     {
@@ -138,7 +139,7 @@ class LsDefConceptController extends AbstractController
      * @Route("/{id}", methods={"DELETE"}, name="lsdef_concept_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
     public function deleteAction(Request $request, LsDefConcept $lsDefConcept): Response
     {
@@ -158,7 +159,7 @@ class LsDefConceptController extends AbstractController
      *
      * @param LsDefConcept $lsDefConcept The LsDefConcept entity
      *
-     * @return \Symfony\Component\Form\FormInterface The form
+     * @return FormInterface The form
      */
     private function createDeleteForm(LsDefConcept $lsDefConcept): FormInterface
     {

--- a/core/src/Controller/Framework/LsDefGradeController.php
+++ b/core/src/Controller/Framework/LsDefGradeController.php
@@ -20,9 +20,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * LsDefGrade controller.
- *
- * @Route("/cfdef/grade")
  */
+#[Route(path: '/cfdef/grade')]
 class LsDefGradeController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -35,11 +34,11 @@ class LsDefGradeController extends AbstractController
     /**
      * Lists all LsDefGrade entities.
      *
-     * @Route("/", methods={"GET"}, name="lsdef_grade_index")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsdef_grade_index')]
     public function indexAction()
     {
         $em = $this->managerRegistry->getManager();
@@ -54,12 +53,12 @@ class LsDefGradeController extends AbstractController
     /**
      * Creates a new LsDefGrade entity.
      *
-     * @Route("/new", methods={"GET", "POST"}, name="lsdef_grade_new")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'lsdef_grade_new')]
     public function newAction(Request $request)
     {
         $lsDefGrade = new LsDefGrade();
@@ -86,11 +85,11 @@ class LsDefGradeController extends AbstractController
     /**
      * Finds and displays a LsDefGrade entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="lsdef_grade_show")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'lsdef_grade_show')]
     public function showAction(LsDefGrade $lsDefGrade)
     {
         $deleteForm = $this->createDeleteForm($lsDefGrade);
@@ -104,12 +103,12 @@ class LsDefGradeController extends AbstractController
     /**
      * Displays a form to edit an existing LsDefGrade entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsdef_grade_edit")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsdef_grade_edit')]
     public function editAction(Request $request, LsDefGrade $lsDefGrade)
     {
         $deleteForm = $this->createDeleteForm($lsDefGrade);
@@ -137,11 +136,11 @@ class LsDefGradeController extends AbstractController
     /**
      * Deletes a LsDefGrade entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsdef_grade_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return RedirectResponse
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsdef_grade_delete')]
     public function deleteAction(Request $request, LsDefGrade $lsDefGrade)
     {
         $form = $this->createDeleteForm($lsDefGrade);

--- a/core/src/Controller/Framework/LsDefGradeController.php
+++ b/core/src/Controller/Framework/LsDefGradeController.php
@@ -14,6 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -57,7 +58,7 @@ class LsDefGradeController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function newAction(Request $request)
     {
@@ -107,7 +108,7 @@ class LsDefGradeController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function editAction(Request $request, LsDefGrade $lsDefGrade)
     {
@@ -139,7 +140,7 @@ class LsDefGradeController extends AbstractController
      * @Route("/{id}", methods={"DELETE"}, name="lsdef_grade_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
     public function deleteAction(Request $request, LsDefGrade $lsDefGrade)
     {
@@ -159,7 +160,7 @@ class LsDefGradeController extends AbstractController
      *
      * @param LsDefGrade $lsDefGrade The LsDefGrade entity
      *
-     * @return \Symfony\Component\Form\FormInterface The form
+     * @return FormInterface The form
      */
     private function createDeleteForm(LsDefGrade $lsDefGrade): FormInterface
     {

--- a/core/src/Controller/Framework/LsDefItemTypeController.php
+++ b/core/src/Controller/Framework/LsDefItemTypeController.php
@@ -14,6 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -91,7 +92,7 @@ class LsDefItemTypeController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function newAction(Request $request)
     {
@@ -141,7 +142,7 @@ class LsDefItemTypeController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function editAction(Request $request, LsDefItemType $lsDefItemType)
     {
@@ -173,7 +174,7 @@ class LsDefItemTypeController extends AbstractController
      * @Route("/{id}", methods={"DELETE"}, name="lsdef_item_type_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
     public function deleteAction(Request $request, LsDefItemType $lsDefItemType)
     {

--- a/core/src/Controller/Framework/LsDefItemTypeController.php
+++ b/core/src/Controller/Framework/LsDefItemTypeController.php
@@ -20,9 +20,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * LsDefItemType controller.
- *
- * @Route("/cfdef/item_type")
  */
+#[Route(path: '/cfdef/item_type')]
 class LsDefItemTypeController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -35,11 +34,11 @@ class LsDefItemTypeController extends AbstractController
     /**
      * Lists all LsDefItemType entities.
      *
-     * @Route("/", methods={"GET"}, name="lsdef_item_type_index")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsdef_item_type_index')]
     public function indexAction()
     {
         $em = $this->managerRegistry->getManager();
@@ -54,11 +53,11 @@ class LsDefItemTypeController extends AbstractController
     /**
      * Lists all LsDefItemType entities.
      *
-     * @Route("/list.{_format}", methods={"GET"}, defaults={"_format"="json"}, name="lsdef_item_type_index_json")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/list.{_format}', methods: ['GET'], defaults: ['_format' => 'json'], name: 'lsdef_item_type_index_json')]
     public function jsonListAction(Request $request)
     {
         // ?page_limit=N&q=SEARCHTEXT
@@ -88,12 +87,12 @@ class LsDefItemTypeController extends AbstractController
     /**
      * Creates a new LsDefItemType entity.
      *
-     * @Route("/new", methods={"GET", "POST"}, name="lsdef_item_type_new")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'lsdef_item_type_new')]
     public function newAction(Request $request)
     {
         $lsDefItemType = new LsDefItemType();
@@ -120,11 +119,11 @@ class LsDefItemTypeController extends AbstractController
     /**
      * Finds and displays a LsDefItemType entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="lsdef_item_type_show")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'lsdef_item_type_show')]
     public function showAction(LsDefItemType $lsDefItemType)
     {
         $deleteForm = $this->createDeleteForm($lsDefItemType);
@@ -138,12 +137,12 @@ class LsDefItemTypeController extends AbstractController
     /**
      * Displays a form to edit an existing LsDefItemType entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsdef_item_type_edit")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsdef_item_type_edit')]
     public function editAction(Request $request, LsDefItemType $lsDefItemType)
     {
         $deleteForm = $this->createDeleteForm($lsDefItemType);
@@ -171,11 +170,11 @@ class LsDefItemTypeController extends AbstractController
     /**
      * Deletes a LsDefItemType entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsdef_item_type_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return RedirectResponse
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsdef_item_type_delete')]
     public function deleteAction(Request $request, LsDefItemType $lsDefItemType)
     {
         $form = $this->createDeleteForm($lsDefItemType);

--- a/core/src/Controller/Framework/LsDefLicenceController.php
+++ b/core/src/Controller/Framework/LsDefLicenceController.php
@@ -20,9 +20,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * LsDefLicence controller.
- *
- * @Route("/cfdef/licence")
  */
+#[Route(path: '/cfdef/licence')]
 class LsDefLicenceController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -35,11 +34,11 @@ class LsDefLicenceController extends AbstractController
     /**
      * Lists all LsDefLicence entities.
      *
-     * @Route("/", methods={"GET"}, name="lsdef_licence_index")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsdef_licence_index')]
     public function indexAction()
     {
         $em = $this->managerRegistry->getManager();
@@ -54,9 +53,9 @@ class LsDefLicenceController extends AbstractController
     /**
      * Lists all LsDefLicence entities.
      *
-     * @Route("/list.{_format}", methods={"GET"}, defaults={"_format"="json"}, name="lsdef_licence_index_json")
      * @Template()
      */
+    #[Route(path: '/list.{_format}', methods: ['GET'], defaults: ['_format' => 'json'], name: 'lsdef_licence_index_json')]
     public function jsonListAction(): array
     {
         $em = $this->managerRegistry->getManager();
@@ -71,12 +70,12 @@ class LsDefLicenceController extends AbstractController
     /**
      * Creates a new LsDefLicence entity.
      *
-     * @Route("/new", methods={"GET", "POST"}, name="lsdef_licence_new")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'lsdef_licence_new')]
     public function newAction(Request $request)
     {
         $lsDefLicence = new LsDefLicence();
@@ -103,11 +102,11 @@ class LsDefLicenceController extends AbstractController
     /**
      * Finds and displays a LsDefLicence entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="lsdef_licence_show")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'lsdef_licence_show')]
     public function showAction(LsDefLicence $lsDefLicence)
     {
         $deleteForm = $this->createDeleteForm($lsDefLicence);
@@ -121,12 +120,12 @@ class LsDefLicenceController extends AbstractController
     /**
      * Displays a form to edit an existing LsDefLicence entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsdef_licence_edit")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsdef_licence_edit')]
     public function editAction(Request $request, LsDefLicence $lsDefLicence)
     {
         $deleteForm = $this->createDeleteForm($lsDefLicence);
@@ -154,11 +153,11 @@ class LsDefLicenceController extends AbstractController
     /**
      * Deletes a LsDefLicence entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsdef_licence_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return RedirectResponse
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsdef_licence_delete')]
     public function deleteAction(Request $request, LsDefLicence $lsDefLicence)
     {
         $form = $this->createDeleteForm($lsDefLicence);

--- a/core/src/Controller/Framework/LsDefLicenceController.php
+++ b/core/src/Controller/Framework/LsDefLicenceController.php
@@ -14,6 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -74,7 +75,7 @@ class LsDefLicenceController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function newAction(Request $request)
     {
@@ -124,7 +125,7 @@ class LsDefLicenceController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function editAction(Request $request, LsDefLicence $lsDefLicence)
     {
@@ -156,7 +157,7 @@ class LsDefLicenceController extends AbstractController
      * @Route("/{id}", methods={"DELETE"}, name="lsdef_licence_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
     public function deleteAction(Request $request, LsDefLicence $lsDefLicence)
     {
@@ -176,7 +177,7 @@ class LsDefLicenceController extends AbstractController
      *
      * @param LsDefLicence $lsDefLicence The LsDefLicence entity
      *
-     * @return \Symfony\Component\Form\FormInterface The form
+     * @return FormInterface The form
      */
     private function createDeleteForm(LsDefLicence $lsDefLicence): FormInterface
     {

--- a/core/src/Controller/Framework/LsDefSubjectController.php
+++ b/core/src/Controller/Framework/LsDefSubjectController.php
@@ -14,6 +14,7 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -78,7 +79,7 @@ class LsDefSubjectController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function newAction(Request $request)
     {
@@ -128,7 +129,7 @@ class LsDefSubjectController extends AbstractController
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
+     * @return array|RedirectResponse
      */
     public function editAction(Request $request, LsDefSubject $lsDefSubject)
     {
@@ -160,7 +161,7 @@ class LsDefSubjectController extends AbstractController
      * @Route("/{id}", methods={"DELETE"}, name="lsdef_subject_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      */
     public function deleteAction(Request $request, LsDefSubject $lsDefSubject)
     {
@@ -180,7 +181,7 @@ class LsDefSubjectController extends AbstractController
      *
      * @param LsDefSubject $lsDefSubject The LsDefSubject entity
      *
-     * @return \Symfony\Component\Form\FormInterface The form
+     * @return FormInterface The form
      */
     private function createDeleteForm(LsDefSubject $lsDefSubject): FormInterface
     {

--- a/core/src/Controller/Framework/LsDefSubjectController.php
+++ b/core/src/Controller/Framework/LsDefSubjectController.php
@@ -20,9 +20,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * LsDefSubject controller.
- *
- * @Route("/cfdef/subject")
  */
+#[Route(path: '/cfdef/subject')]
 class LsDefSubjectController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -35,11 +34,11 @@ class LsDefSubjectController extends AbstractController
     /**
      * Lists all LsDefSubject entities.
      *
-     * @Route("/", methods={"GET"}, name="lsdef_subject_index")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsdef_subject_index')]
     public function indexAction()
     {
         $em = $this->managerRegistry->getManager();
@@ -54,11 +53,11 @@ class LsDefSubjectController extends AbstractController
     /**
      * Lists all LsDefSubject entities.
      *
-     * @Route("/list.{_format}", methods={"GET"}, defaults={"_format"="json"}, name="lsdef_subject_index_json")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/list.{_format}', methods: ['GET'], defaults: ['_format' => 'json'], name: 'lsdef_subject_index_json')]
     public function jsonListAction(Request $request)
     {
         // ?page_limit=N&q=SEARCHTEXT
@@ -75,12 +74,12 @@ class LsDefSubjectController extends AbstractController
     /**
      * Creates a new LsDefSubject entity.
      *
-     * @Route("/new", methods={"GET", "POST"}, name="lsdef_subject_new")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'lsdef_subject_new')]
     public function newAction(Request $request)
     {
         $lsDefSubject = new LsDefSubject();
@@ -107,11 +106,11 @@ class LsDefSubjectController extends AbstractController
     /**
      * Finds and displays a LsDefSubject entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="lsdef_subject_show")
      * @Template()
      *
      * @return array
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'lsdef_subject_show')]
     public function showAction(LsDefSubject $lsDefSubject)
     {
         $deleteForm = $this->createDeleteForm($lsDefSubject);
@@ -125,12 +124,12 @@ class LsDefSubjectController extends AbstractController
     /**
      * Displays a form to edit an existing LsDefSubject entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsdef_subject_edit")
      * @Template()
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return array|RedirectResponse
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsdef_subject_edit')]
     public function editAction(Request $request, LsDefSubject $lsDefSubject)
     {
         $deleteForm = $this->createDeleteForm($lsDefSubject);
@@ -158,11 +157,11 @@ class LsDefSubjectController extends AbstractController
     /**
      * Deletes a LsDefSubject entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsdef_subject_delete")
      * @Security("is_granted('create', 'lsdoc')")
      *
      * @return RedirectResponse
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsdef_subject_delete')]
     public function deleteAction(Request $request, LsDefSubject $lsDefSubject)
     {
         $form = $this->createDeleteForm($lsDefSubject);

--- a/core/src/Controller/Framework/LsDocController.php
+++ b/core/src/Controller/Framework/LsDocController.php
@@ -17,6 +17,7 @@ use App\Form\Type\LsDocType;
 use App\Form\Type\RemoteCaseServerType;
 use Doctrine\Persistence\ManagerRegistry;
 use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
@@ -90,7 +91,7 @@ class LsDocController extends AbstractController
         ]);
     }
 
-    protected function loadDocumentsFromServer(string $urlPrefix): \Psr\Http\Message\ResponseInterface
+    protected function loadDocumentsFromServer(string $urlPrefix): ResponseInterface
     {
         $jsonClient = new Client();
         $list = $jsonClient->request(

--- a/core/src/Controller/Framework/LsDocController.php
+++ b/core/src/Controller/Framework/LsDocController.php
@@ -282,7 +282,7 @@ class LsDocController extends AbstractController
                     $this->deleteFramework($lsDoc);
 
                     return new JsonResponse('OK');
-                } catch (\Exception $e) {
+                } catch (\Exception) {
                     return new JsonResponse(['error' => ['message' => 'Error deleting framework']], Response::HTTP_BAD_REQUEST);
                 }
             }
@@ -336,12 +336,12 @@ class LsDocController extends AbstractController
             $remoteResponse = $this->loadDocumentsFromServer(
                 'https://'.$hostname
             );
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             try {
                 $remoteResponse = $this->loadDocumentsFromServer(
                     'http://'.$hostname
                 );
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 throw new \Exception("Could not access CASE API on {$hostname}.");
             }
         }
@@ -368,7 +368,7 @@ class LsDocController extends AbstractController
                     return $a['title'] <=> $b['title'];
                 }
             );
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $docs = null;
         }
 

--- a/core/src/Controller/Framework/LsDocController.php
+++ b/core/src/Controller/Framework/LsDocController.php
@@ -28,9 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/**
- * @Route("/cfdoc")
- */
+#[Route(path: '/cfdoc')]
 class LsDocController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -42,9 +40,8 @@ class LsDocController extends AbstractController
 
     /**
      * Lists all LsDoc entities.
-     *
-     * @Route("/", methods={"GET"}, name="lsdoc_index")
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsdoc_index')]
     public function indexAction(?UserInterface $user = null): Response
     {
         $em = $this->managerRegistry->getManager();
@@ -68,9 +65,8 @@ class LsDocController extends AbstractController
 
     /**
      * Show frameworks from a remote system.
-     *
-     * @Route("/remote", methods={"GET", "POST"}, name="lsdoc_remote_index")
      */
+    #[Route(path: '/remote', methods: ['GET', 'POST'], name: 'lsdoc_remote_index')]
     public function remoteIndexAction(Request $request): Response
     {
         $form = $this->createForm(RemoteCaseServerType::class);
@@ -111,9 +107,9 @@ class LsDocController extends AbstractController
     /**
      * Creates a new LsDoc entity.
      *
-     * @Route("/new", methods={"GET", "POST"}, name="lsdoc_new")
      * @Security("is_granted('create', 'lsdoc')")
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'lsdoc_new')]
     public function newAction(Request $request): Response
     {
         $lsDoc = new LsDoc();
@@ -143,9 +139,9 @@ class LsDocController extends AbstractController
     /**
      * Finds and displays a LsDoc entity.
      *
-     * @Route("/{id}.{_format}", methods={"GET"}, defaults={"_format"="html"}, name="lsdoc_show")
      * @Security("is_granted('view', lsDoc)")
      */
+    #[Route(path: '/{id}.{_format}', methods: ['GET'], defaults: ['_format' => 'html'], name: 'lsdoc_show')]
     public function showAction(LsDoc $lsDoc, string $_format = 'html'): Response
     {
         if ('json' === $_format) {
@@ -166,11 +162,11 @@ class LsDocController extends AbstractController
     /**
      * Update a framework given a CSV or external File.
      *
-     * @Route("/doc/{id}/update", methods={"POST"}, name="lsdoc_update")
      * @Security("is_granted('edit', lsDoc)")
      *
      * @deprecated It appears this is unused now
      */
+    #[Route(path: '/doc/{id}/update', methods: ['POST'], name: 'lsdoc_update')]
     public function updateAction(Request $request, LsDoc $lsDoc): Response
     {
         $response = new JsonResponse();
@@ -190,9 +186,9 @@ class LsDocController extends AbstractController
     /**
      * Update a framework given a CSV or external File on a derivative framework.
      *
-     * @Route("/doc/{id}/derive", methods={"POST"}, name="lsdoc_update_derive")
      * @Security("is_granted('create', 'lsdoc')")
      */
+    #[Route(path: '/doc/{id}/derive', methods: ['POST'], name: 'lsdoc_update_derive')]
     public function deriveAction(Request $request, LsDoc $lsDoc): Response
     {
         $fileContent = $request->request->get('content');
@@ -211,9 +207,9 @@ class LsDocController extends AbstractController
     /**
      * Displays a form to edit an existing LsDoc entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsdoc_edit")
      * @Security("is_granted('edit', lsDoc)")
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsdoc_edit')]
     public function editAction(Request $request, LsDoc $lsDoc, UserInterface $user): Response
     {
         $ajax = $request->isXmlHttpRequest();
@@ -274,9 +270,9 @@ class LsDocController extends AbstractController
     /**
      * Deletes a LsDoc entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsdoc_delete")
      * @Security("is_granted('delete', lsDoc)")
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsdoc_delete')]
     public function deleteAction(Request $request, LsDoc $lsDoc): Response
     {
         if ($request->isXmlHttpRequest()) {
@@ -307,9 +303,9 @@ class LsDocController extends AbstractController
     /**
      * Finds and displays a LsDoc entity.
      *
-     * @Route("/{id}/export.{_format}", methods={"GET"}, requirements={"_format"="(json|html|null)"}, defaults={"_format"="json"}, name="lsdoc_export")
      * @Security("is_granted('view', lsDoc)")
      */
+    #[Route(path: '/{id}/export.{_format}', methods: ['GET'], requirements: ['_format' => '(json|html|null)'], defaults: ['_format' => 'json'], name: 'lsdoc_export')]
     public function exportAction(LsDoc $lsDoc, string $_format = 'json'): Response
     {
         if ('json' !== $_format) {

--- a/core/src/Controller/Framework/LsItemController.php
+++ b/core/src/Controller/Framework/LsItemController.php
@@ -72,7 +72,7 @@ class LsItemController extends AbstractController
      * @Template()
      * @Security("is_granted('add-standard-to', doc)")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return array|RedirectResponse|Response
      */
     public function newAction(Request $request, LsDoc $doc, ?LsItem $parent = null, ?LsDefAssociationGrouping $assocGroup = null)
     {
@@ -150,7 +150,7 @@ class LsItemController extends AbstractController
      * @Template()
      * @Security("is_granted('edit', lsItem)")
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return array|RedirectResponse|Response
      */
     public function editAction(Request $request, LsItem $lsItem, UserInterface $user)
     {
@@ -267,7 +267,7 @@ class LsItemController extends AbstractController
      * @Security("is_granted('edit', lsItem)")
      * @Template()
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return array|RedirectResponse|Response
      */
     public function copyAction(Request $request, LsItem $lsItem)
     {
@@ -317,7 +317,7 @@ class LsItemController extends AbstractController
      * @Security("is_granted('edit', lsItem)")
      * @Template()
      *
-     * @return array|\Symfony\Component\HttpFoundation\RedirectResponse|Response
+     * @return array|RedirectResponse|Response
      */
     public function changeParentAction(Request $request, LsItem $lsItem)
     {

--- a/core/src/Controller/Framework/LsItemController.php
+++ b/core/src/Controller/Framework/LsItemController.php
@@ -37,9 +37,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
  * LsItem controller.
- *
- * @Route("/cfitem")
  */
+#[Route(path: '/cfitem')]
 class LsItemController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -56,9 +55,9 @@ class LsItemController extends AbstractController
     /**
      * Lists all LsItem entities.
      *
-     * @Route("/", methods={"GET"}, name="lsitem_index")
      * @Template()
      */
+    #[Route(path: '/', methods: ['GET'], name: 'lsitem_index')]
     public function indexAction(): array
     {
         return [];
@@ -67,13 +66,13 @@ class LsItemController extends AbstractController
     /**
      * Creates a new LsItem entity.
      *
-     * @Route("/new/{doc}/{parent}", methods={"GET", "POST"}, name="lsitem_new")
-     * @Route("/new/{doc}/{parent}/{assocGroup}", methods={"GET", "POST"}, name="lsitem_new_ag")
      * @Template()
      * @Security("is_granted('add-standard-to', doc)")
      *
      * @return array|RedirectResponse|Response
      */
+    #[Route(path: '/new/{doc}/{parent}', methods: ['GET', 'POST'], name: 'lsitem_new')]
+    #[Route(path: '/new/{doc}/{parent}/{assocGroup}', methods: ['GET', 'POST'], name: 'lsitem_new_ag')]
     public function newAction(Request $request, LsDoc $doc, ?LsItem $parent = null, ?LsDefAssociationGrouping $assocGroup = null)
     {
         $ajax = $request->isXmlHttpRequest();
@@ -121,13 +120,13 @@ class LsItemController extends AbstractController
     /**
      * Finds and displays a LsItem entity.
      *
-     * @Route("/{id}.{_format}", methods={"GET"}, defaults={"_format"="html"}, name="lsitem_show")
      * @Template()
      *
      * @param string $_format
      *
      * @return array
      */
+    #[Route(path: '/{id}.{_format}', methods: ['GET'], defaults: ['_format' => 'html'], name: 'lsitem_show')]
     public function showAction(LsItem $lsItem, $_format = 'html')
     {
         if ('json' === $_format) {
@@ -146,12 +145,12 @@ class LsItemController extends AbstractController
     /**
      * Displays a form to edit an existing LsItem entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="lsitem_edit")
      * @Template()
      * @Security("is_granted('edit', lsItem)")
      *
      * @return array|RedirectResponse|Response
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'lsitem_edit')]
     public function editAction(Request $request, LsItem $lsItem, UserInterface $user)
     {
         $ajax = $request->isXmlHttpRequest();
@@ -202,9 +201,9 @@ class LsItemController extends AbstractController
     /**
      * Deletes a LsItem entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="lsitem_delete")
      * @Security("is_granted('edit', lsItem)")
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'lsitem_delete')]
     public function deleteAction(Request $request, LsItem $lsItem): RedirectResponse
     {
         $form = $this->createDeleteForm($lsItem);
@@ -235,9 +234,9 @@ class LsItemController extends AbstractController
     /**
      * Export an LsItem entity.
      *
-     * @Route("/{id}/export", methods={"GET"}, defaults={"_format"="json"}, name="lsitem_export")
      * @Template()
      */
+    #[Route(path: '/{id}/export', methods: ['GET'], defaults: ['_format' => 'json'], name: 'lsitem_export')]
     public function exportAction(LsItem $lsItem): array
     {
         return [
@@ -248,10 +247,10 @@ class LsItemController extends AbstractController
     /**
      * Remove a child LSItem.
      *
-     * @Route("/{id}/removeChild/{child}", methods={"POST"}, name="lsitem_remove_child")
      * @Security("is_granted('edit', lsItem)")
      * @Template()
      */
+    #[Route(path: '/{id}/removeChild/{child}', methods: ['POST'], name: 'lsitem_remove_child')]
     public function removeChildAction(LsItem $parent, LsItem $child): array
     {
         $command = new RemoveChildCommand($parent, $child);
@@ -263,12 +262,12 @@ class LsItemController extends AbstractController
     /**
      * Copy an LsItem to a new LsDoc.
      *
-     * @Route("/{id}/copy", methods={"GET", "POST"}, name="lsitem_copy_item")
      * @Security("is_granted('edit', lsItem)")
      * @Template()
      *
      * @return array|RedirectResponse|Response
      */
+    #[Route(path: '/{id}/copy', methods: ['GET', 'POST'], name: 'lsitem_copy_item')]
     public function copyAction(Request $request, LsItem $lsItem)
     {
         // Steps
@@ -313,12 +312,12 @@ class LsItemController extends AbstractController
     /**
      * Displays a form to change the parent of an existing LsItem entity.
      *
-     * @Route("/{id}/parent", methods={"GET", "POST"}, name="lsitem_change_parent")
      * @Security("is_granted('edit', lsItem)")
      * @Template()
      *
      * @return array|RedirectResponse|Response
      */
+    #[Route(path: '/{id}/parent', methods: ['GET', 'POST'], name: 'lsitem_change_parent')]
     public function changeParentAction(Request $request, LsItem $lsItem)
     {
         $ajax = $request->isXmlHttpRequest();
@@ -356,10 +355,10 @@ class LsItemController extends AbstractController
     /**
      * Upload attachment to LsItem entity.
      *
-     * @Route("/{id}/upload_attachment", methods={"POST"}, name="lsitem_upload_attachment")
      * @Template()
      * @Security("is_granted('add-standard-to', doc)")
      */
+    #[Route(path: '/{id}/upload_attachment', methods: ['POST'], name: 'lsitem_upload_attachment')]
     public function uploadAttachmentAction(Request $request, LsDoc $doc, BucketService $bucket): Response
     {
         if (!empty($this->bucketProvider)) {

--- a/core/src/Controller/GithubImportController.php
+++ b/core/src/Controller/GithubImportController.php
@@ -17,9 +17,7 @@ class GithubImportController extends AbstractController
 {
     use CommandDispatcherTrait;
 
-    /**
-     * @Route("/cf/github/import", name="import_from_github")
-     */
+    #[Route(path: '/cf/github/import', name: 'import_from_github')]
     public function importAction(Request $request): JsonResponse
     {
         /** @var array $lsItemKeys - argument passed as an array */

--- a/core/src/Controller/GithubOauthController.php
+++ b/core/src/Controller/GithubOauthController.php
@@ -20,10 +20,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class GithubOauthController extends AbstractController
 {
     /**
-     * @Route("/user/github/repos")
-     *
      * @return JsonResponse
      */
+    #[Route(path: '/user/github/repos')]
     public function getReposAction(Request $request)
     {
         $currentUser = $this->getUser();
@@ -61,10 +60,9 @@ class GithubOauthController extends AbstractController
     }
 
     /**
-     * @Route("/user/github/files")
-     *
      * @return JsonResponse
      */
+    #[Route(path: '/user/github/files')]
     public function getFilesAction(Request $request)
     {
         $currentUser = $this->getUser();

--- a/core/src/Controller/GithubOauthController.php
+++ b/core/src/Controller/GithubOauthController.php
@@ -3,10 +3,13 @@
 namespace App\Controller;
 
 use App\Entity\User\User;
+use Milo\Github\Api;
+use Milo\Github\OAuth\Token;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -27,7 +30,7 @@ class GithubOauthController extends AbstractController
         $response = new JsonResponse();
 
         if (!$currentUser instanceof User) {
-            $response->setStatusCode(401);
+            $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
 
             return $response->setData([
                 'message' => 'Please log in.',
@@ -38,8 +41,8 @@ class GithubOauthController extends AbstractController
             $page = $request->query->get('page');
             $perPage = $request->query->get('perPage');
 
-            $token = new \Milo\Github\OAuth\Token($currentUser->getGithubToken());
-            $api = new \Milo\Github\Api();
+            $token = new Token($currentUser->getGithubToken());
+            $api = new Api();
             $api->setToken($token);
 
             $repos = $api->get('/user/repos?page='.$page.'&per_page='.$perPage);
@@ -50,7 +53,7 @@ class GithubOauthController extends AbstractController
             ]);
         }
 
-        $response->setStatusCode(401);
+        $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
 
         return $response->setData([
             'message' => 'Please log in with your GitHub account',
@@ -67,15 +70,15 @@ class GithubOauthController extends AbstractController
         $currentUser = $this->getUser();
         $response = new JsonResponse();
         if (!$currentUser instanceof User) {
-            $response->setStatusCode(401);
+            $response->setStatusCode(Response::HTTP_UNAUTHORIZED);
 
             return $response->setData([
                 'message' => 'Please log in.',
             ]);
         }
 
-        $token = new \Milo\Github\OAuth\Token($currentUser->getGithubToken());
-        $api = new \Milo\Github\Api();
+        $token = new Token($currentUser->getGithubToken());
+        $api = new Api();
         $api->setToken($token);
 
         $owner = $request->query->get('owner');

--- a/core/src/Controller/ImportLogsController.php
+++ b/core/src/Controller/ImportLogsController.php
@@ -16,11 +16,11 @@ class ImportLogsController extends AbstractController
     use CommandDispatcherTrait;
 
     /**
-     * @Route("/cfdoc/{doc}/import_logs/mark_as_read", methods={"POST"}, name="mark_import_logs_as_read")
      * @Security("is_granted('edit', doc)")
      *
      * @return JsonResponse
      */
+    #[Route(path: '/cfdoc/{doc}/import_logs/mark_as_read', methods: ['POST'], name: 'mark_import_logs_as_read')]
     public function markAsReadAction(LsDoc $doc): Response
     {
         $command = new MarkImportLogsAsReadCommand($doc);

--- a/core/src/Controller/Mirror/FrameworkController.php
+++ b/core/src/Controller/Mirror/FrameworkController.php
@@ -18,8 +18,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Security("is_granted('manage', 'mirrors')")
- * @Route("/admin/mirror/framework")
  */
+#[Route(path: '/admin/mirror/framework')]
 class FrameworkController extends AbstractController
 {
     public function __construct(
@@ -27,9 +27,7 @@ class FrameworkController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/new", name="mirror_framework_new")
-     */
+    #[Route(path: '/new', name: 'mirror_framework_new')]
     public function new(Request $request, MirrorServer $mirrorService): Response
     {
         $frameworkDto = new MirroredFrameworkDTO();
@@ -53,9 +51,7 @@ class FrameworkController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}/resolve-id-conflict", name="mirror_framework_resolve_conflict")
-     */
+    #[Route(path: '/{id}/resolve-id-conflict', name: 'mirror_framework_resolve_conflict')]
     public function resolveConflict(Request $request, Framework $framework): Response
     {
         $em = $this->managerRegistry->getManager();
@@ -101,9 +97,7 @@ class FrameworkController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}/refresh", methods={"POST"}, name="mirror_framework_refresh")
-     */
+    #[Route(path: '/{id}/refresh', methods: ['POST'], name: 'mirror_framework_refresh')]
     public function refresh(Framework $framework): Response
     {
         $framework->markToRefresh();
@@ -112,9 +106,7 @@ class FrameworkController extends AbstractController
         return $this->redirectToRoute('mirror_server_list', ['id' => $framework->getServer()->getId()]);
     }
 
-    /**
-     * @Route("/{id}/enable", methods={"POST"}, name="mirror_framework_enable")
-     */
+    #[Route(path: '/{id}/enable', methods: ['POST'], name: 'mirror_framework_enable')]
     public function enable(Framework $framework): Response
     {
         $framework->setInclude(true);
@@ -130,9 +122,7 @@ class FrameworkController extends AbstractController
         return $this->redirectToRoute('mirror_server_list', ['id' => $framework->getServer()->getId()]);
     }
 
-    /**
-     * @Route("/{id}/disable", methods={"POST"}, name="mirror_framework_disable")
-     */
+    #[Route(path: '/{id}/disable', methods: ['POST'], name: 'mirror_framework_disable')]
     public function disable(Framework $framework): Response
     {
         $framework->setInclude(false);
@@ -150,9 +140,7 @@ class FrameworkController extends AbstractController
         return $this->redirectToRoute('mirror_server_list', ['id' => $framework->getServer()->getId()]);
     }
 
-    /**
-     * @Route("/{id}/logs", name="mirror_framework_logs")
-     */
+    #[Route(path: '/{id}/logs', name: 'mirror_framework_logs')]
     public function viewLog(Framework $framework): Response
     {
         return $this->render('mirror/framework/logs.html.twig', [

--- a/core/src/Controller/Mirror/OAuthCredentialsController.php
+++ b/core/src/Controller/Mirror/OAuthCredentialsController.php
@@ -15,8 +15,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Security("is_granted('manage', 'mirrors')")
- * @Route("/admin/mirror/credentials")
  */
+#[Route(path: '/admin/mirror/credentials')]
 class OAuthCredentialsController extends AbstractController
 {
     public function __construct(
@@ -24,9 +24,7 @@ class OAuthCredentialsController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/", name="oauth_credentials_index", methods={"GET"})
-     */
+    #[Route(path: '/', name: 'oauth_credentials_index', methods: ['GET'])]
     public function index(OAuthCredentialRepository $oAuthCredentialRepository): Response
     {
         return $this->render('mirror/oauth_credentials/index.html.twig', [
@@ -34,9 +32,7 @@ class OAuthCredentialsController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/new", name="oauth_credentials_new", methods={"GET","POST"})
-     */
+    #[Route(path: '/new', name: 'oauth_credentials_new', methods: ['GET', 'POST'])]
     public function new(Request $request): Response
     {
         $oAuthCredentialDto = new OAuthCredentialDTO();
@@ -62,9 +58,7 @@ class OAuthCredentialsController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}", name="oauth_credentials_show", methods={"GET"})
-     */
+    #[Route(path: '/{id}', name: 'oauth_credentials_show', methods: ['GET'])]
     public function show(OAuthCredential $oAuthCredential): Response
     {
         return $this->render('mirror/oauth_credentials/show.html.twig', [
@@ -72,9 +66,7 @@ class OAuthCredentialsController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}/edit", name="oauth_credentials_edit", methods={"GET","POST"})
-     */
+    #[Route(path: '/{id}/edit', name: 'oauth_credentials_edit', methods: ['GET', 'POST'])]
     public function edit(Request $request, OAuthCredential $oAuthCredential): Response
     {
         $dto = new OAuthCredentialDTO();
@@ -100,9 +92,7 @@ class OAuthCredentialsController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}", name="oauth_credentials_delete", methods={"DELETE"})
-     */
+    #[Route(path: '/{id}', name: 'oauth_credentials_delete', methods: ['DELETE'])]
     public function delete(Request $request, OAuthCredential $oAuthCredential): Response
     {
         if ($this->isCsrfTokenValid('delete'.$oAuthCredential->getId(), $request->request->get('_token'))) {

--- a/core/src/Controller/Mirror/ServerController.php
+++ b/core/src/Controller/Mirror/ServerController.php
@@ -18,8 +18,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @Security("is_granted('manage', 'mirrors')")
- * @Route("/admin/mirror/server")
  */
+#[Route(path: '/admin/mirror/server')]
 class ServerController extends AbstractController
 {
     public function __construct(
@@ -27,9 +27,7 @@ class ServerController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/", name="mirror_server_index")
-     */
+    #[Route(path: '/', name: 'mirror_server_index')]
     public function index(ServerRepository $serverRepository): Response
     {
         $servers = $serverRepository->findAllForList();
@@ -66,9 +64,7 @@ class ServerController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/new", name="mirror_server_add")
-     */
+    #[Route(path: '/new', name: 'mirror_server_add')]
     public function new(Request $request, MirrorServer $mirrorService): Response
     {
         // Multiple steps
@@ -95,9 +91,7 @@ class ServerController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}/edit", name="mirror_server_edit")
-     */
+    #[Route(path: '/{id}/edit', name: 'mirror_server_edit')]
     public function edit(Request $request, Server $server, MirrorServer $mirrorService): Response
     {
         $serverDto = new MirroredServerDTO();
@@ -125,9 +119,7 @@ class ServerController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}/list", name="mirror_server_list")
-     */
+    #[Route(path: '/{id}/list', name: 'mirror_server_list')]
     public function list(Server $server): Response
     {
         $enableForms = [];
@@ -162,9 +154,7 @@ class ServerController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}", methods={"GET", "DELETE"}, name="mirror_server_delete")
-     */
+    #[Route(path: '/{id}', methods: ['GET', 'DELETE'], name: 'mirror_server_delete')]
     public function remove(Request $request, Server $server): Response
     {
         $form = $this->createDeleteForm($server);
@@ -194,9 +184,7 @@ class ServerController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/{id}/refresh", methods={"POST"}, name="mirror_server_refresh")
-     */
+    #[Route(path: '/{id}/refresh', methods: ['POST'], name: 'mirror_server_refresh')]
     public function refresh(Server $server, MirrorServer $mirrorServer): Response
     {
         $mirrorServer->updateFrameworkList($server);

--- a/core/src/Controller/PdfExportController.php
+++ b/core/src/Controller/PdfExportController.php
@@ -24,7 +24,7 @@ class PdfExportController extends AbstractController
 
         $response = $this->forward('App\Controller\Framework\CfPackageController::exportAction', ['id' => $id, '_format' => 'json']);
         $data_array = json_decode($response->getContent(), true);
-        for ($i = 0, $iMax = count($data_array['CFItems']); $i < $iMax; ++$i) {
+        for ($i = 0, $iMax = is_countable($data_array['CFItems']) ? count($data_array['CFItems']) : 0; $i < $iMax; ++$i) {
             $data_array['CFItems'][$i]['fullStatement'] = $this->renderImages($data_array['CFItems'][$i]['fullStatement']);
             if (isset($data_array['CFItems'][$i]['notes'])) {
                 $data_array['CFItems'][$i]['notes'] = $this->renderImages($data_array['CFItems'][$i]['notes']);

--- a/core/src/Controller/PdfExportController.php
+++ b/core/src/Controller/PdfExportController.php
@@ -8,6 +8,7 @@ use PhpOffice\PhpWord\PhpWord;
 use PhpOffice\PhpWord\Settings;
 use PhpOffice\PhpWord\Shared\Html;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -46,7 +47,7 @@ class PdfExportController extends AbstractController
                 IOFactory::createWriter($phpWordObject, 'PDF')
                     ->save('php://output');
             },
-            200,
+            Response::HTTP_OK,
             [
                 'Content-Type' => 'application/PDF',
                 'Content-Disposition' => 'attachment; filename="'.$file.'"',

--- a/core/src/Controller/PdfExportController.php
+++ b/core/src/Controller/PdfExportController.php
@@ -23,7 +23,7 @@ class PdfExportController extends AbstractController
         $section = $phpWordObject->addSection();
 
         $response = $this->forward('App\Controller\Framework\CfPackageController::exportAction', ['id' => $id, '_format' => 'json']);
-        $data_array = json_decode($response->getContent(), true);
+        $data_array = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
         for ($i = 0, $iMax = is_countable($data_array['CFItems']) ? count($data_array['CFItems']) : 0; $i < $iMax; ++$i) {
             $data_array['CFItems'][$i]['fullStatement'] = $this->renderImages($data_array['CFItems'][$i]['fullStatement']);
             if (isset($data_array['CFItems'][$i]['notes'])) {

--- a/core/src/Controller/PdfExportController.php
+++ b/core/src/Controller/PdfExportController.php
@@ -16,9 +16,7 @@ class PdfExportController extends AbstractController
 {
     use CommandDispatcherTrait;
 
-    /**
-     * @Route("/cfdoc/{id}/pdf", methods={"GET"}, name="export_pdf_file")
-     */
+    #[Route(path: '/cfdoc/{id}/pdf', methods: ['GET'], name: 'export_pdf_file')]
     public function exportPdfAction(int $id): StreamedResponse
     {
         $phpWordObject = new PhpWord();

--- a/core/src/Controller/SessionController.php
+++ b/core/src/Controller/SessionController.php
@@ -21,9 +21,7 @@ class SessionController extends AbstractController
         $this->sessionMaxIdleTime = $sessionMaxIdleTime;
     }
 
-    /**
-     * @Route("/session/check")
-     */
+    #[Route(path: '/session/check')]
     public function currentSession(Request $request, SessionRepository $repo): JsonResponse
     {
         if (null === ($sessionId = $request->cookies->get('session'))) {
@@ -43,9 +41,7 @@ class SessionController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/session/renew")
-     */
+    #[Route(path: '/session/renew')]
     public function renewSession(): JsonResponse
     {
         return new JsonResponse([

--- a/core/src/Controller/SessionController.php
+++ b/core/src/Controller/SessionController.php
@@ -6,6 +6,7 @@ use App\Repository\SessionRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 class SessionController extends AbstractController
@@ -26,15 +27,15 @@ class SessionController extends AbstractController
     public function currentSession(Request $request, SessionRepository $repo): JsonResponse
     {
         if (null === ($sessionId = $request->cookies->get('session'))) {
-            return new JsonResponse(null, 404);
+            return new JsonResponse(null, Response::HTTP_NOT_FOUND);
         }
 
         if (null === ($session = $repo->findSession($sessionId))) {
-            return new JsonResponse(null, 404);
+            return new JsonResponse(null, Response::HTTP_NOT_FOUND);
         }
 
         if (0 > ($remainingTime = $this->sessionMaxIdleTime - (time() - $session->getLastUsed()))) {
-            return new JsonResponse(null, 404);
+            return new JsonResponse(null, Response::HTTP_NOT_FOUND);
         }
 
         return new JsonResponse([

--- a/core/src/Controller/Site/AboutController.php
+++ b/core/src/Controller/Site/AboutController.php
@@ -18,9 +18,7 @@ class AboutController extends AbstractController
         $this->projectDir = $projectDir;
     }
 
-    /**
-     * @Route("/about", name="site_about")
-     */
+    #[Route(path: '/about', name: 'site_about')]
     public function aboutAction(): Response
     {
         if (file_exists($this->projectDir.'/public/version.txt')) {

--- a/core/src/Controller/Site/DevController.php
+++ b/core/src/Controller/Site/DevController.php
@@ -12,9 +12,9 @@ use Symfony\Component\Routing\Annotation\Route;
 class DevController extends AbstractController
 {
     /**
-     * @Route("/dev/cookie", name="dev_cookie")
      * @Security("is_granted('feature', 'dev_env')")
      */
+    #[Route(path: '/dev/cookie', name: 'dev_cookie')]
     public function devCookieAction(Request $request): Response
     {
         if (empty($cookie = $request->server->get('DEV_COOKIE'))) {
@@ -24,7 +24,7 @@ class DevController extends AbstractController
         }
 
         $response = $this->redirectToRoute('salt_index');
-        $response->headers->setCookie(new Cookie('dev', $cookie, 'now + 1 year'));
+        $response->headers->setCookie(Cookie::create('dev', $cookie, 'now + 1 year'));
         $this->addFlash('success', 'Development cookie set.');
 
         return $response;

--- a/core/src/Controller/SystemLogController.php
+++ b/core/src/Controller/SystemLogController.php
@@ -11,9 +11,9 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/admin/system_log")
  * @Security("is_granted('manage', 'system_logs')")
  */
+#[Route(path: '/admin/system_log')]
 class SystemLogController extends AbstractController
 {
     private ChangeEntryRepository $entryRepository;
@@ -23,17 +23,13 @@ class SystemLogController extends AbstractController
         $this->entryRepository = $entryRepository;
     }
 
-    /**
-     * @Route("/", methods={"GET"}, name="system_logs_show")
-     */
+    #[Route(path: '/', methods: ['GET'], name: 'system_logs_show')]
     public function showSystemLogs(): Response
     {
         return $this->render('system_log/show_system_logs.html.twig');
     }
 
-    /**
-     * @Route("/revisions/{offset}/{limit}", methods={"GET"}, requirements={"offset" = "\d+", "limit" = "\d+"}, defaults={"offset" = 0, "limit" = 0}, name="system_logs_json")
-     */
+    #[Route(path: '/revisions/{offset}/{limit}', methods: ['GET'], requirements: ['offset' => '\d+', 'limit' => '\d+'], defaults: ['offset' => 0, 'limit' => 0], name: 'system_logs_json')]
     public function listDocRevisionsAction(int $offset = 0, int $limit = 0): Response
     {
         $response = new StreamedResponse();
@@ -62,9 +58,7 @@ class SystemLogController extends AbstractController
         return $response;
     }
 
-    /**
-     * @Route("/revisions/count", methods={"GET"}, name="system_logs_count")
-     */
+    #[Route(path: '/revisions/count', methods: ['GET'], name: 'system_logs_count')]
     public function changeLogCount(): Response
     {
         $count = $this->entryRepository->getChangeEntryCountForSystem();
@@ -72,9 +66,7 @@ class SystemLogController extends AbstractController
         return new JsonResponse($count);
     }
 
-    /**
-     * @Route("/export", methods={"GET"}, name="system_logs_csv")
-     */
+    #[Route(path: '/export', methods: ['GET'], name: 'system_logs_csv')]
     public function exportSystemLogs(): Response
     {
         $response = new StreamedResponse();

--- a/core/src/Controller/UiInfoController.php
+++ b/core/src/Controller/UiInfoController.php
@@ -12,9 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/treeuiinfo")
- */
+#[Route(path: '/treeuiinfo')]
 class UiInfoController extends AbstractController
 {
     public function __construct(
@@ -23,9 +21,9 @@ class UiInfoController extends AbstractController
     }
 
     /**
-     * @Route("/multi/{id}", methods={"POST"}, name="multi_tree_info_json")
      * @Security("is_granted('edit', doc)")
      */
+    #[Route(path: '/multi/{id}', methods: ['POST'], name: 'multi_tree_info_json')]
     public function multiJsonInfoAction(Request $request, LsDoc $doc): JsonResponse
     {
         $objs = [];
@@ -70,27 +68,27 @@ class UiInfoController extends AbstractController
     }
 
     /**
-     * @Route("/doc/{id}", methods={"GET"}, name="lsdoc_tree_json")
      * @Security("is_granted('edit', doc)")
      */
+    #[Route(path: '/doc/{id}', methods: ['GET'], name: 'lsdoc_tree_json')]
     public function docJsonInfoAction(LsDoc $doc): JsonResponse
     {
         return $this->generateDocJsonResponse($doc);
     }
 
     /**
-     * @Route("/item/{id}", methods={"GET"}, name="lsitem_tree_json")
      * @Security("is_granted('edit', item)")
      */
+    #[Route(path: '/item/{id}', methods: ['GET'], name: 'lsitem_tree_json')]
     public function itemJsonInfoAction(LsItem $item): JsonResponse
     {
         return $this->generateItemJsonResponse($item);
     }
 
     /**
-     * @Route("/association/{id}", methods={"GET"}, name="doc_tree_association_json")
      * @Security("is_granted('edit', association.getLsDoc())")
      */
+    #[Route(path: '/association/{id}', methods: ['GET'], name: 'doc_tree_association_json')]
     public function associationJsonInfoAction(LsAssociation $association): JsonResponse
     {
         return $this->generateAssociationJsonResponse($association);

--- a/core/src/Controller/UiInfoController.php
+++ b/core/src/Controller/UiInfoController.php
@@ -177,7 +177,7 @@ class UiInfoController extends AbstractController
 
         $json = $this->renderView('framework/doc_tree/export_item.json.twig', ['lsItem' => $ret]);
 
-        return \json_decode($json, true);
+        return \json_decode($json, true, 512, JSON_THROW_ON_ERROR);
     }
 
     protected function generateAssociationJsonResponse(LsAssociation $association): JsonResponse

--- a/core/src/Controller/UriController.php
+++ b/core/src/Controller/UriController.php
@@ -61,7 +61,7 @@ class UriController extends AbstractController
         }
 
         if ('tree' === $request->getRequestFormat()) {
-            switch (get_class($obj)) {
+            switch ($obj::class) {
                 case LsDoc::class:
                     return $this->redirectToRoute('doc_tree_view', ['slug' => $obj->getId()]);
 
@@ -91,7 +91,7 @@ class UriController extends AbstractController
         $headers['TCN'] = 'choice';
         $response->headers->add($headers);
 
-        $className = $isPackage ? 'CFPackage' : substr(strrchr(get_class($obj), '\\'), 1);
+        $className = $isPackage ? 'CFPackage' : substr(strrchr($obj::class, '\\'), 1);
         $groups = ['default', $className];
         if ('opensalt' === $request->getRequestFormat()) {
             $groups[] = 'opensalt';

--- a/core/src/Controller/UriController.php
+++ b/core/src/Controller/UriController.php
@@ -24,9 +24,7 @@ class UriController extends AbstractController
     ) {
     }
 
-    /**
-     * @Route("/uri/", methods={"GET"}, defaults={"_format"="html"}, name="uri_lookup_empty")
-     */
+    #[Route(path: '/uri/', methods: ['GET'], defaults: ['_format' => 'html'], name: 'uri_lookup_empty')]
     public function findEmptyUriAction(Request $request): Response
     {
         $this->determineRequestFormat($request, null);
@@ -42,9 +40,7 @@ class UriController extends AbstractController
         return $this->render('uri/no_uri.html.twig', ['uri' => null], new Response('', Response::HTTP_NOT_FOUND));
     }
 
-    /**
-     * @Route("/uri/{uri}.{_format}", methods={"GET"}, defaults={"_format"=null}, name="uri_lookup")
-     */
+    #[Route(path: '/uri/{uri}.{_format}', methods: ['GET'], defaults: ['_format' => null], name: 'uri_lookup')]
     public function findUriAction(Request $request, string $uri, ?string $_format): Response
     {
         if ($request->isXmlHttpRequest()) {

--- a/core/src/Controller/User/ChangePasswordController.php
+++ b/core/src/Controller/User/ChangePasswordController.php
@@ -27,9 +27,7 @@ class ChangePasswordController extends AbstractController
     {
     }
 
-    /**
-     * @Route("/user/change-password", name="user_change_password")
-     */
+    #[Route(path: '/user/change-password', name: 'user_change_password')]
     public function changePasswordAction(Request $request): Response
     {
         $dto = new ChangePasswordDTO();

--- a/core/src/Controller/User/FrameworkAclController.php
+++ b/core/src/Controller/User/FrameworkAclController.php
@@ -57,9 +57,7 @@ class FrameworkAclController extends AbstractController
         $acls = $lsDoc->getDocAcls();
         /** @var \ArrayIterator $iterator */
         $iterator = $acls->getIterator();
-        $iterator->uasort(function (UserDocAcl $a, UserDocAcl $b) {
-            return strcasecmp($a->getUser()->getUserIdentifier(), $b->getUser()->getUserIdentifier());
-        });
+        $iterator->uasort(fn (UserDocAcl $a, UserDocAcl $b) => strcasecmp($a->getUser()->getUserIdentifier(), $b->getUser()->getUserIdentifier()));
         $acls = new ArrayCollection(iterator_to_array($iterator));
 
         $deleteForms = [];

--- a/core/src/Controller/User/FrameworkAclController.php
+++ b/core/src/Controller/User/FrameworkAclController.php
@@ -24,17 +24,15 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-/**
- * @Route("/cfdoc")
- */
+#[Route(path: '/cfdoc')]
 class FrameworkAclController extends AbstractController
 {
     use CommandDispatcherTrait;
 
     /**
-     * @Route("/{id}/acl", methods={"GET", "POST"}, name="framework_acl_edit")
      * @Security("is_granted('manage_editors', lsDoc)")
      */
+    #[Route(path: '/{id}/acl', methods: ['GET', 'POST'], name: 'framework_acl_edit')]
     public function editAction(Request $request, LsDoc $lsDoc): Response
     {
         $addAclUserDto = new AddAclUserDTO($lsDoc, UserDocAcl::DENY);
@@ -145,9 +143,9 @@ class FrameworkAclController extends AbstractController
     }
 
     /**
-     * @Route("/{id}/acl/{targetUser}", methods={"DELETE"}, name="framework_acl_remove")
      * @Security("is_granted('manage_editors', lsDoc)")
      */
+    #[Route(path: '/{id}/acl/{targetUser}', methods: ['DELETE'], name: 'framework_acl_remove')]
     public function removeAclAction(Request $request, LsDoc $lsDoc, User $targetUser): RedirectResponse
     {
         $form = $this->createDeleteForm($lsDoc, $targetUser);

--- a/core/src/Controller/User/FrameworkAclController.php
+++ b/core/src/Controller/User/FrameworkAclController.php
@@ -101,7 +101,7 @@ class FrameworkAclController extends AbstractController
                 $error = new FormError($e->getMessage());
                 $error->setOrigin($addOrgUserForm);
                 $addOrgUserForm->addError($error);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $error = new FormError('Unknown Error');
                 $error->setOrigin($addOrgUserForm);
                 $addOrgUserForm->addError($error);
@@ -129,7 +129,7 @@ class FrameworkAclController extends AbstractController
                 $error = new FormError($e->getMessage());
                 $error->setOrigin($addUsernameForm);
                 $addUsernameForm->addError($error);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 //$error = new FormError($e->getMessage().' '.get_class($e));
                 $error = new FormError('Unknown Error');
                 $error->setOrigin($addUsernameForm);

--- a/core/src/Controller/User/OAuthServiceController.php
+++ b/core/src/Controller/User/OAuthServiceController.php
@@ -8,6 +8,7 @@ use App\Entity\User\User;
 use Doctrine\Persistence\ManagerRegistry;
 use League\OAuth2\Client\Provider\Github;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -50,7 +51,7 @@ class OAuthServiceController extends AbstractController
      *
      * @Route("/check-github", methods={"GET"}, name="github_login")
      *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     * @return RedirectResponse
      *
      * @throws \UnexpectedValueException
      */

--- a/core/src/Controller/User/OAuthServiceController.php
+++ b/core/src/Controller/User/OAuthServiceController.php
@@ -17,9 +17,8 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * OAuth Service controller.
- *
- * @Route("/login")
  */
+#[Route(path: '/login')]
 class OAuthServiceController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -49,12 +48,11 @@ class OAuthServiceController extends AbstractController
     /**
      * Save the Github Access Token.
      *
-     * @Route("/check-github", methods={"GET"}, name="github_login")
-     *
      * @return RedirectResponse
      *
      * @throws \UnexpectedValueException
      */
+    #[Route(path: '/check-github', methods: ['GET'], name: 'github_login')]
     public function githubAction(Request $request, SessionInterface $session, ManagerRegistry $managerRegistry): Response
     {
         if (!empty($this->githubRedirectUri)) {

--- a/core/src/Controller/User/OrganizationController.php
+++ b/core/src/Controller/User/OrganizationController.php
@@ -21,9 +21,9 @@ use Symfony\Component\Routing\Annotation\Route;
 /**
  * Organization controller.
  *
- * @Route("/admin/organization")
  * @Security("is_granted('manage', 'organizations')")
  */
+#[Route(path: '/admin/organization')]
 class OrganizationController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -35,9 +35,8 @@ class OrganizationController extends AbstractController
 
     /**
      * Lists all organization entities.
-     *
-     * @Route("/", methods={"GET"}, name="admin_organization_index")
      */
+    #[Route(path: '/', methods: ['GET'], name: 'admin_organization_index')]
     public function index(): Response
     {
         $em = $this->managerRegistry->getManager();
@@ -51,9 +50,8 @@ class OrganizationController extends AbstractController
 
     /**
      * Creates a new organization entity.
-     *
-     * @Route("/new", methods={"GET", "POST"}, name="admin_organization_new")
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'admin_organization_new')]
     public function create(Request $request): Response
     {
         $organization = new Organization();
@@ -79,9 +77,8 @@ class OrganizationController extends AbstractController
 
     /**
      * Finds and displays an organization entity.
-     *
-     * @Route("/{id}", methods={"GET"}, name="admin_organization_show")
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'admin_organization_show')]
     public function show(Organization $organization): Response
     {
         $deleteForm = $this->createDeleteForm($organization);
@@ -94,9 +91,8 @@ class OrganizationController extends AbstractController
 
     /**
      * Displays a form to edit an existing organization entity.
-     *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="admin_organization_edit")
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'admin_organization_edit')]
     public function edit(Request $request, Organization $organization): Response
     {
         $deleteForm = $this->createDeleteForm($organization);
@@ -123,9 +119,8 @@ class OrganizationController extends AbstractController
 
     /**
      * Deletes an organization entity.
-     *
-     * @Route("/{id}", methods={"DELETE"}, name="admin_organization_delete")
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'admin_organization_delete')]
     public function delete(Request $request, Organization $organization): RedirectResponse
     {
         $form = $this->createDeleteForm($organization);

--- a/core/src/Controller/User/SecurityController.php
+++ b/core/src/Controller/User/SecurityController.php
@@ -20,9 +20,7 @@ class SecurityController extends AbstractController
         $this->authenticationUtils = $authenticationUtils;
     }
 
-    /**
-     * @Route("/login", name="login")
-     */
+    #[Route(path: '/login', name: 'login')]
     public function loginAction(Request $request): Response
     {
         // get the login error if there is one
@@ -40,9 +38,7 @@ class SecurityController extends AbstractController
         ]);
     }
 
-    /**
-     * @Route("/logout", name="app_logout")
-     */
+    #[Route(path: '/logout', name: 'app_logout')]
     public function logout(): void
     {
         throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');

--- a/core/src/Controller/User/SecurityController.php
+++ b/core/src/Controller/User/SecurityController.php
@@ -39,7 +39,7 @@ class SecurityController extends AbstractController
     }
 
     #[Route(path: '/logout', name: 'app_logout')]
-    public function logout(): void
+    public function logout(): never
     {
         throw new \LogicException('This method can be blank - it will be intercepted by the logout key on your firewall.');
     }

--- a/core/src/Controller/User/SignupController.php
+++ b/core/src/Controller/User/SignupController.php
@@ -110,7 +110,7 @@ class SignupController extends AbstractController
                 return $this->redirectToRoute('lsdoc_index');
             } catch (\Exception $e) {
                 if ('dev' === $this->kernelEnv) {
-                    $form->addError(new FormError(get_class($e).': '.$e->getMessage()));
+                    $form->addError(new FormError($e::class.': '.$e->getMessage()));
                 } else {
                     $form->addError(new FormError('Sorry, an error occurred while creating your account.'));
                 }

--- a/core/src/Controller/User/SignupController.php
+++ b/core/src/Controller/User/SignupController.php
@@ -21,9 +21,9 @@ use Symfony\Component\Routing\Annotation\Route;
 /**
  * Signup Controller.
  *
- * @Route("/public/user")
  * @Toggle("create_account")
  */
+#[Route(path: '/public/user')]
 class SignupController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -37,9 +37,8 @@ class SignupController extends AbstractController
 
     /**
      * Creates a new user entity.
-     *
-     * @Route("/signup", methods={"GET", "POST"}, name="public_user_signup")
      */
+    #[Route(path: '/signup', methods: ['GET', 'POST'], name: 'public_user_signup')]
     public function signupAction(Request $request): Response
     {
         $targetUser = new User();

--- a/core/src/Controller/User/UserController.php
+++ b/core/src/Controller/User/UserController.php
@@ -211,9 +211,9 @@ class UserController extends AbstractController
         try {
             $command = new SendUserApprovedEmailCommand($targetUser->getUserIdentifier());
             $this->sendCommand($command);
-        } catch (\Swift_RfcComplianceException $e) {
+        } catch (\Swift_RfcComplianceException) {
             throw new \RuntimeException('A valid email address must be given.');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Do not throw an error to the client if the email could not be sent
         }
 

--- a/core/src/Controller/User/UserController.php
+++ b/core/src/Controller/User/UserController.php
@@ -26,9 +26,9 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 /**
  * User controller.
  *
- * @Route("/admin/user")
  * @Security("is_granted('manage', 'users')")
  */
+#[Route(path: '/admin/user')]
 class UserController extends AbstractController
 {
     use CommandDispatcherTrait;
@@ -42,9 +42,8 @@ class UserController extends AbstractController
 
     /**
      * Lists all user entities.
-     *
-     * @Route("/", methods={"GET"}, name="admin_user_index")
      */
+    #[Route(path: '/', methods: ['GET'], name: 'admin_user_index')]
     public function index(): Response
     {
         $em = $this->managerRegistry->getManager();
@@ -81,9 +80,8 @@ class UserController extends AbstractController
 
     /**
      * Creates a new user entity.
-     *
-     * @Route("/new", methods={"GET", "POST"}, name="admin_user_new")
      */
+    #[Route(path: '/new', methods: ['GET', 'POST'], name: 'admin_user_new')]
     public function create(Request $request): Response
     {
         $targetUser = new User();
@@ -124,9 +122,9 @@ class UserController extends AbstractController
     /**
      * Finds and displays a user entity.
      *
-     * @Route("/{id}", methods={"GET"}, name="admin_user_show")
      * @Security("is_granted('manage', targetUser)")
      */
+    #[Route(path: '/{id}', methods: ['GET'], name: 'admin_user_show')]
     public function show(User $targetUser): Response
     {
         $deleteForm = $this->createDeleteForm($targetUser);
@@ -140,9 +138,9 @@ class UserController extends AbstractController
     /**
      * Displays a form to edit an existing user entity.
      *
-     * @Route("/{id}/edit", methods={"GET", "POST"}, name="admin_user_edit")
      * @Security("is_granted('manage', targetUser)")
      */
+    #[Route(path: '/{id}/edit', methods: ['GET', 'POST'], name: 'admin_user_edit')]
     public function edit(Request $request, User $targetUser): Response
     {
         $deleteForm = $this->createDeleteForm($targetUser);
@@ -177,9 +175,9 @@ class UserController extends AbstractController
     /**
      * Suspend a user.
      *
-     * @Route("/{id}/suspend", methods={"POST"}, name="admin_user_suspend")
      * @Security("is_granted('manage', targetUser)")
      */
+    #[Route(path: '/{id}/suspend', methods: ['POST'], name: 'admin_user_suspend')]
     public function suspend(Request $request, User $targetUser): RedirectResponse
     {
         $form = $this->createSuspendForm($targetUser);
@@ -196,9 +194,9 @@ class UserController extends AbstractController
     /**
      * Activate a user.
      *
-     * @Route("/{id}/activate", methods={"POST"}, name="admin_user_activate")
      * @Security("is_granted('manage', targetUser)")
      */
+    #[Route(path: '/{id}/activate', methods: ['POST'], name: 'admin_user_activate')]
     public function activate(Request $request, User $targetUser): RedirectResponse
     {
         $form = $this->createActivateForm($targetUser);
@@ -225,9 +223,9 @@ class UserController extends AbstractController
     /**
      * Reject a user.
      *
-     * @Route("/{id}/reject", methods={"POST"}, name="admin_user_reject")
      * @Security("is_granted('manage', targetUser)")
      */
+    #[Route(path: '/{id}/reject', methods: ['POST'], name: 'admin_user_reject')]
     public function reject(Request $request, User $targetUser): RedirectResponse
     {
         $form = $this->createRejectForm($targetUser);
@@ -244,9 +242,9 @@ class UserController extends AbstractController
     /**
      * Deletes a user entity.
      *
-     * @Route("/{id}", methods={"DELETE"}, name="admin_user_delete")
      * @Security("is_granted('manage', targetUser)")
      */
+    #[Route(path: '/{id}', methods: ['DELETE'], name: 'admin_user_delete')]
     public function delete(Request $request, User $targetUser): RedirectResponse
     {
         $form = $this->createDeleteForm($targetUser);

--- a/core/src/DTO/Api1/ImsxCodeMinorField.php
+++ b/core/src/DTO/Api1/ImsxCodeMinorField.php
@@ -4,15 +4,15 @@ namespace App\DTO\Api1;
 
 class ImsxCodeMinorField
 {
-    public const CODE_MINOR_FULLSUCCESS = 'fullsuccess';
-    public const CODE_MINOR_INVALID_SORT = 'invalid_sort_field';
-    public const CODE_MINOR_INVALID_SELECTION = 'invalid_selection_field';
-    public const CODE_MINOR_FORBIDDEN = 'forbidden';
-    public const CODE_MINOR_UNAUTHORISED = 'unauthorisedrequest';
-    public const CODE_MINOR_INTERNAL_SERVER_ERROR = 'internal_server_error';
-    public const CODE_MINOR_UNKNOWN_OBJECT = 'unknownobject';
-    public const CODE_MINOR_SERVER_BUSY = 'server_busy';
-    public const CODE_MINOR_INVALID_UUID = 'invaliduuid';
+    final public const CODE_MINOR_FULLSUCCESS = 'fullsuccess';
+    final public const CODE_MINOR_INVALID_SORT = 'invalid_sort_field';
+    final public const CODE_MINOR_INVALID_SELECTION = 'invalid_selection_field';
+    final public const CODE_MINOR_FORBIDDEN = 'forbidden';
+    final public const CODE_MINOR_UNAUTHORISED = 'unauthorisedrequest';
+    final public const CODE_MINOR_INTERNAL_SERVER_ERROR = 'internal_server_error';
+    final public const CODE_MINOR_UNKNOWN_OBJECT = 'unknownobject';
+    final public const CODE_MINOR_SERVER_BUSY = 'server_busy';
+    final public const CODE_MINOR_INVALID_UUID = 'invaliduuid';
 
     public static array $codeMinorValues = [
         self::CODE_MINOR_FULLSUCCESS,

--- a/core/src/DTO/Api1/ImsxStatusInfo.php
+++ b/core/src/DTO/Api1/ImsxStatusInfo.php
@@ -4,14 +4,14 @@ namespace App\DTO\Api1;
 
 class ImsxStatusInfo
 {
-    public const CODE_MAJOR_SUCCESS = 'success';
-    public const CODE_MAJOR_PROCESSING = 'processing';
-    public const CODE_MAJOR_FAILURE = 'failure';
-    public const CODE_MAJOR_UNSUPPORTED = 'unsupported';
+    final public const CODE_MAJOR_SUCCESS = 'success';
+    final public const CODE_MAJOR_PROCESSING = 'processing';
+    final public const CODE_MAJOR_FAILURE = 'failure';
+    final public const CODE_MAJOR_UNSUPPORTED = 'unsupported';
 
-    public const SEVERITY_STATUS = 'status';
-    public const SEVERITY_WARNING = 'warning';
-    public const SEVERITY_ERROR = 'error';
+    final public const SEVERITY_STATUS = 'status';
+    final public const SEVERITY_WARNING = 'warning';
+    final public const SEVERITY_ERROR = 'error';
 
     public static array $codeMajorValues = [
         self::CODE_MAJOR_SUCCESS,

--- a/core/src/DTO/CaseJson/CFDefinition.php
+++ b/core/src/DTO/CaseJson/CFDefinition.php
@@ -8,36 +8,31 @@ class CFDefinition
 {
     /**
      * @var CFConcept[]|array|null
-     *
-     * @SerializedName("CFConcepts")
      */
+    #[SerializedName('CFConcepts')]
     public ?array $cfConcepts = [];
 
     /**
      * @var CFSubject[]|array|null
-     *
-     * @SerializedName("CFSubjects")
      */
+    #[SerializedName('CFSubjects')]
     public ?array $cfSubjects = [];
 
     /**
      * @var CFLicense[]|array|null
-     *
-     * @SerializedName("CFLicenses")
      */
+    #[SerializedName('CFLicenses')]
     public ?array $cfLicenses = [];
 
     /**
      * @var CFItemType[]|array|null
-     *
-     * @SerializedName("CFItemTypes")
      */
+    #[SerializedName('CFItemTypes')]
     public ?array $cfItemTypes = [];
 
     /**
      * @var CFAssociationGrouping[]|array|null
-     *
-     * @SerializedName("CFAssociationGroupings")
      */
+    #[SerializedName('CFAssociationGroupings')]
     public ?array $cfAssociationGroupings = [];
 }

--- a/core/src/DTO/CaseJson/CFPackage.php
+++ b/core/src/DTO/CaseJson/CFPackage.php
@@ -6,34 +6,27 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 
 class CFPackage
 {
-    /**
-     * @SerializedName("CFDocument")
-     */
+    #[SerializedName('CFDocument')]
     public CFPackageDocument $cfDocument;
 
     /**
      * @var CFPackageItem[]|array|null
-     *
-     * @SerializedName("CFItems")
      */
+    #[SerializedName('CFItems')]
     public ?array $cfItems = [];
 
     /**
      * @var CFPackageAssociation[]|array|null
-     *
-     * @SerializedName("CFAssociations")
      */
+    #[SerializedName('CFAssociations')]
     public ?array $cfAssociations = [];
 
-    /**
-     * @SerializedName("CFDefinitions")
-     */
+    #[SerializedName('CFDefinitions')]
     public ?CFDefinition $cfDefinitions = null;
 
     /**
      * @var CFRubric[]|array|null
-     *
-     * @SerializedName("CFRubrics")
      */
+    #[SerializedName('CFRubrics')]
     public ?array $cfRubrics = [];
 }

--- a/core/src/DTO/CaseJson/CFPackageAssociation.php
+++ b/core/src/DTO/CaseJson/CFPackageAssociation.php
@@ -14,9 +14,7 @@ class CFPackageAssociation
     public LinkGenURI $originNodeURI;
     public LinkGenURI $destinationNodeURI;
 
-    /**
-     * @SerializedName("CFAssociationGroupingURI")
-     */
+    #[SerializedName('CFAssociationGroupingURI')]
     public ?LinkURI $cfAssociationGroupingURI = null;
 
     public \DateTimeInterface $lastChangeDateTime;

--- a/core/src/DTO/CaseJson/CFPackageItem.php
+++ b/core/src/DTO/CaseJson/CFPackageItem.php
@@ -12,9 +12,7 @@ class CFPackageItem
     public string $fullStatement;
     public ?string $alternativeLabel = null;
 
-    /**
-     * @SerializedName("CFItemType")
-     */
+    #[SerializedName('CFItemType')]
     public ?string $cfItemType = null;
 
     public ?string $humanCodingScheme = null;
@@ -31,9 +29,7 @@ class CFPackageItem
     /** @var string[]|array|string|null */
     public string|array|null $educationLevel = null;
 
-    /**
-     * @SerializedName("CFItemTypeURI")
-     */
+    #[SerializedName('CFItemTypeURI')]
     public ?LinkURI $cfItemTypeURI = null;
     public ?LinkURI $licenseURI = null;
     public ?\DateTimeInterface $statusStartDate = null;

--- a/core/src/DTO/CaseJson/CFRubric.php
+++ b/core/src/DTO/CaseJson/CFRubric.php
@@ -15,8 +15,7 @@ class CFRubric
 
     /**
      * @var CFRubricCriterion[]|array|null
-     *
-     * @SerializedName("CFRubricCriteria")
      */
+    #[SerializedName('CFRubricCriteria')]
     public ?array $cfRubricCriteria = [];
 }

--- a/core/src/DTO/CaseJson/CFRubricCriterion.php
+++ b/core/src/DTO/CaseJson/CFRubricCriterion.php
@@ -12,9 +12,7 @@ class CFRubricCriterion
     public ?string $category = null;
     public ?string $description = null;
 
-    /**
-     * @SerializedName("CFItemURI")
-     */
+    #[SerializedName('CFItemURI')]
     public ?LinkURI $cfItemURI = null;
 
     public ?float $weight = null;
@@ -24,8 +22,7 @@ class CFRubricCriterion
 
     /**
      * @var CFRubricCriterionLevel[]|array|null
-     *
-     * @SerializedName("CFRubricCriterionLevels")
      */
+    #[SerializedName('CFRubricCriterionLevels')]
     public ?array $cfRubricCriterionLevels = [];
 }

--- a/core/src/DataTransformer/CaseJson/AssociationGroupingsTransformer.php
+++ b/core/src/DataTransformer/CaseJson/AssociationGroupingsTransformer.php
@@ -43,9 +43,7 @@ class AssociationGroupingsTransformer
         /** @var LsDefAssociationGroupingRepository $repo */
         $repo = $this->em->getRepository(LsDefAssociationGrouping::class);
 
-        $newIds = array_map(static function (CFAssociationGrouping $group) {
-            return $group->identifier->toString();
-        }, $cfAssociationGroupings);
+        $newIds = array_map(static fn (CFAssociationGrouping $group) => $group->identifier->toString(), $cfAssociationGroupings);
 
         return $repo->findByIdentifier($newIds);
     }

--- a/core/src/DataTransformer/CaseJson/AssociationsTransformer.php
+++ b/core/src/DataTransformer/CaseJson/AssociationsTransformer.php
@@ -62,9 +62,7 @@ class AssociationsTransformer
         /** @var LsAssociationRepository $repo */
         $repo = $this->em->getRepository(LsAssociation::class);
 
-        $newIds = array_map(static function (CFPackageAssociation $item) {
-            return $item->identifier->toString();
-        }, $cfAssociations);
+        $newIds = array_map(static fn (CFPackageAssociation $item) => $item->identifier->toString(), $cfAssociations);
 
         return $repo->findByIdentifiers($newIds);
     }

--- a/core/src/DataTransformer/CaseJson/ConceptsTransformer.php
+++ b/core/src/DataTransformer/CaseJson/ConceptsTransformer.php
@@ -43,9 +43,7 @@ class ConceptsTransformer
         /** @var LsDefConceptRepository $repo */
         $repo = $this->em->getRepository(LsDefConcept::class);
 
-        $newIds = array_map(static function (CFConcept $itemType) {
-            return $itemType->identifier->toString();
-        }, $cfConcepts);
+        $newIds = array_map(static fn (CFConcept $itemType) => $itemType->identifier->toString(), $cfConcepts);
 
         return $repo->findByIdentifiers($newIds);
     }

--- a/core/src/DataTransformer/CaseJson/ItemTypesTransformer.php
+++ b/core/src/DataTransformer/CaseJson/ItemTypesTransformer.php
@@ -43,9 +43,7 @@ class ItemTypesTransformer
         /** @var LsDefItemTypeRepository $repo */
         $repo = $this->em->getRepository(LsDefItemType::class);
 
-        $newIds = array_map(static function (CFItemType $itemType) {
-            return $itemType->identifier->toString();
-        }, $cfItemTypes);
+        $newIds = array_map(static fn (CFItemType $itemType) => $itemType->identifier->toString(), $cfItemTypes);
 
         return $repo->findByIdentifiers($newIds);
     }

--- a/core/src/DataTransformer/CaseJson/ItemsTransformer.php
+++ b/core/src/DataTransformer/CaseJson/ItemsTransformer.php
@@ -53,9 +53,7 @@ class ItemsTransformer
         /** @var LsItemRepository $repo */
         $repo = $this->em->getRepository(LsItem::class);
 
-        $newIds = array_map(static function (CFPackageItem $item) {
-            return $item->identifier->toString();
-        }, $cfItems);
+        $newIds = array_map(static fn (CFPackageItem $item) => $item->identifier->toString(), $cfItems);
 
         return $repo->findByIdentifiers($newIds);
     }

--- a/core/src/DataTransformer/CaseJson/LicencesTransformer.php
+++ b/core/src/DataTransformer/CaseJson/LicencesTransformer.php
@@ -43,9 +43,7 @@ class LicencesTransformer
         /** @var LsDefLicenceRepository $repo */
         $repo = $this->em->getRepository(LsDefLicence::class);
 
-        $newIds = array_map(static function (CFLicense $itemType) {
-            return $itemType->identifier->toString();
-        }, $cfLicences);
+        $newIds = array_map(static fn (CFLicense $itemType) => $itemType->identifier->toString(), $cfLicences);
 
         return $repo->findByIdentifiers($newIds);
     }

--- a/core/src/DataTransformer/CaseJson/RubricsTransformer.php
+++ b/core/src/DataTransformer/CaseJson/RubricsTransformer.php
@@ -55,9 +55,7 @@ class RubricsTransformer
      */
     private function findExistingRubrics(array $cfRubrics): array
     {
-        $identifiers = array_map(static function (CFPackageRubric $rubric) {
-            return $rubric->identifier->toString();
-        }, $cfRubrics);
+        $identifiers = array_map(static fn (CFPackageRubric $rubric) => $rubric->identifier->toString(), $cfRubrics);
 
         return $this->em->getRepository(CfRubric::class)->findByIdentifier($identifiers);
     }
@@ -87,15 +85,11 @@ class RubricsTransformer
      */
     private function updateCriteria(CfRubric $rubric, array $cfCriteria): void
     {
-        $newCriteria = array_combine(array_map(static function (CFPackageCriterion $cfCriterion) {
-            return $cfCriterion->identifier->toString();
-        }, $cfCriteria), $cfCriteria);
+        $newCriteria = array_combine(array_map(static fn (CFPackageCriterion $cfCriterion) => $cfCriterion->identifier->toString(), $cfCriteria), $cfCriteria);
 
         $tmpCriteria = $rubric->getCriteria()->toArray();
         /** @var CfRubricCriterion[] $existingCriteria */
-        $existingCriteria = array_combine(array_map(static function (CfRubricCriterion $criterion) {
-            return $criterion->getIdentifier();
-        }, $tmpCriteria), $tmpCriteria);
+        $existingCriteria = array_combine(array_map(static fn (CfRubricCriterion $criterion) => $criterion->getIdentifier(), $tmpCriteria), $tmpCriteria);
         $tmpCriteria = null;
 
         $criteria = [];
@@ -159,14 +153,10 @@ class RubricsTransformer
      */
     private function updateLevels(CfRubricCriterion $criterion, array $cfRubricCriterionLevels): array
     {
-        $newLevels = array_combine(array_map(static function (CFPackageCriterionLevel $cfCriterionLevel) {
-            return $cfCriterionLevel->identifier->toString();
-        }, $cfRubricCriterionLevels), $cfRubricCriterionLevels);
+        $newLevels = array_combine(array_map(static fn (CFPackageCriterionLevel $cfCriterionLevel) => $cfCriterionLevel->identifier->toString(), $cfRubricCriterionLevels), $cfRubricCriterionLevels);
 
         $tmpLevels = $criterion->getLevels()->toArray();
-        $existingLevels = array_combine(array_map(static function (CfRubricCriterionLevel $level) {
-            return $level->getIdentifier();
-        }, $tmpLevels), $tmpLevels);
+        $existingLevels = array_combine(array_map(static fn (CfRubricCriterionLevel $level) => $level->getIdentifier(), $tmpLevels), $tmpLevels);
         $tmpLevels = null;
 
         $levels = [];

--- a/core/src/DataTransformer/CaseJson/SubjectsTransformer.php
+++ b/core/src/DataTransformer/CaseJson/SubjectsTransformer.php
@@ -43,9 +43,7 @@ class SubjectsTransformer
         /** @var LsDefSubjectRepository $repo */
         $repo = $this->em->getRepository(LsDefSubject::class);
 
-        $newIds = array_map(static function (CFSubject $subject) {
-            return $subject->identifier->toString();
-        }, $subjects);
+        $newIds = array_map(static fn (CFSubject $subject) => $subject->identifier->toString(), $subjects);
 
         return $repo->findByIdentifiers($newIds);
     }

--- a/core/src/Entity/Asn/AsnBase.php
+++ b/core/src/Entity/Asn/AsnBase.php
@@ -31,7 +31,7 @@ abstract class AsnBase
         if (str_starts_with($name, 'set')) {
             $prop = lcfirst(preg_replace('/^set/', '', $name));
             if (array_key_exists($prop, static::$properties)) {
-                if (1 !== count($args)) {
+                if (1 !== (is_countable($args) ? count($args) : 0)) {
                     throw new \BadMethodCallException("{$name} requires an argument");
                 }
                 $this->property[$prop] = $args[0];

--- a/core/src/Entity/Asn/AsnBase.php
+++ b/core/src/Entity/Asn/AsnBase.php
@@ -83,7 +83,7 @@ abstract class AsnBase
 
     public static function fromJson(string $json): static
     {
-        $arr = json_decode($json);
+        $arr = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
 
         return static::fromArray($arr);
     }

--- a/core/src/Entity/Asn/AsnDocument.php
+++ b/core/src/Entity/Asn/AsnDocument.php
@@ -84,7 +84,7 @@ final class AsnDocument
 
     public static function fromJson(string $json): self
     {
-        $arr = json_decode($json, true);
+        $arr = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
 
         return self::fromArray($arr);
     }

--- a/core/src/Entity/Asn/AsnValue.php
+++ b/core/src/Entity/Asn/AsnValue.php
@@ -59,7 +59,7 @@ final class AsnValue
 
     public static function fromJson(string $json): static
     {
-        $arr = json_decode($json);
+        $arr = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
 
         return static::fromArray($arr);
     }

--- a/core/src/Entity/ChangeEntry.php
+++ b/core/src/Entity/ChangeEntry.php
@@ -4,58 +4,38 @@ namespace App\Entity;
 
 use App\Entity\Framework\LsDoc;
 use App\Entity\User\User;
+use App\Repository\ChangeEntryRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
-/**
- * @ORM\Table(name="salt_change",
- *     indexes={
- *         @ORM\Index(name="change_time_idx", columns={"changed_at"}),
- *         @ORM\Index(name="doc_idx", columns={"doc_id", "changed_at"})
- *     }
- * )
- * @ORM\Entity(repositoryClass="App\Repository\ChangeEntryRepository")
- */
+#[ORM\Table(name: 'salt_change', indexes: [new ORM\Index(columns: ['changed_at'], name: 'change_time_idx'), new ORM\Index(columns: ['doc_id', 'changed_at'], name: 'doc_idx')])]
+#[ORM\Entity(repositoryClass: ChangeEntryRepository::class)]
 class ChangeEntry
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="bigint")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    protected $id;
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: 'bigint')]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    protected ?int $id;
 
-    /**
-     * @ORM\Column(name="user_id", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'user_id', type: 'integer', nullable: true)]
     protected ?int $user;
 
-    /**
-     * @ORM\Column(name="username", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'username', type: 'string', nullable: true)]
     protected ?string $username;
 
-    /**
-     * @ORM\Column(name="doc_id", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'doc_id', type: 'integer', nullable: true)]
     protected ?int $doc;
 
     /**
-     * @ORM\Column(name="changed_at", type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
+    #[ORM\Column(name: 'changed_at', type: 'datetime', precision: 6)]
     protected \DateTimeInterface $changedAt;
 
-    /**
-     * @ORM\Column(name="description", type="string", length=2048)
-     */
+    #[ORM\Column(name: 'description', type: 'string', length: 2048)]
     protected string $description;
 
-    /**
-     * @ORM\Column(name="changed", type="json", nullable=true)
-     */
+    #[ORM\Column(name: 'changed', type: 'json', nullable: true)]
     protected array $changed = [];
 
     public function __construct(?LsDoc $doc, ?User $user, string $description, array $changed = [])

--- a/core/src/Entity/ChangeEntry.php
+++ b/core/src/Entity/ChangeEntry.php
@@ -15,7 +15,7 @@ class ChangeEntry
     #[ORM\Id]
     #[ORM\Column(name: 'id', type: 'bigint')]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id;
+    protected ?int $id = null;
 
     #[ORM\Column(name: 'user_id', type: 'integer', nullable: true)]
     protected ?int $user;

--- a/core/src/Entity/Comment/Comment.php
+++ b/core/src/Entity/Comment/Comment.php
@@ -5,97 +5,73 @@ namespace App\Entity\Comment;
 use App\Entity\Framework\LsDoc;
 use App\Entity\Framework\LsItem;
 use App\Entity\User\User;
+use App\Repository\CommentRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
-/**
- * @ORM\Entity(repositoryClass="App\Repository\CommentRepository")
- * @ORM\Table(name="salt_comment")
- */
+#[ORM\Entity(repositoryClass: CommentRepository::class)]
+#[ORM\Table(name: 'salt_comment')]
 class Comment
 {
-    /**
-     * @var int
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(type="integer")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="Comment")
-     * @ORM\JoinColumn(nullable=true, onDelete="CASCADE")
-     */
+    #[ORM\ManyToOne(targetEntity: Comment::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
     private ?Comment $parent = null;
 
-    /**
-     * @ORM\Column(type="text")
-     */
+    #[ORM\Column(type: 'text')]
     private string $content;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\User\User")
-     * @ORM\JoinColumn(nullable=false)
-     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
     private User $user;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Framework\LsDoc")
-     * @ORM\JoinColumn(nullable=true, onDelete="CASCADE")
-     */
+    #[ORM\ManyToOne(targetEntity: LsDoc::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
     private ?LsDoc $document = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Framework\LsItem")
-     * @ORM\JoinColumn(nullable=true, onDelete="CASCADE")
-     */
+    #[ORM\ManyToOne(targetEntity: LsItem::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]
     private ?LsItem $item = null;
 
     /**
      * @var Collection<array-key, CommentUpvote>
-     *
-     * @ORM\OneToMany(targetEntity="CommentUpvote", mappedBy="comment")
      */
+    #[ORM\OneToMany(mappedBy: 'comment', targetEntity: CommentUpvote::class)]
     private Collection $upvotes;
 
     /**
-     * @ORM\Column(type="datetime", precision=6)
      * @Gedmo\Timestampable(on="create")
      */
-    private \DateTime $createdAt;
+    #[ORM\Column(type: 'datetime', precision: 6)]
+    private \DateTimeInterface $createdAt;
 
     /**
-     * @ORM\Column(type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
-    private \DateTime $updatedAt;
+    #[ORM\Column(type: 'datetime', precision: 6)]
+    private \DateTimeInterface $updatedAt;
 
-    /**
-     * @ORM\Column(type="string", length=255, nullable=true)
-     */
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $fileUrl = null;
 
-    /**
-     * @ORM\Column(type="string", length=255, nullable=true)
-     */
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $fileMimeType = null;
 
-    /**
-     * @var bool
-     */
-    private $createdByCurrentUser = false;
+    private bool $createdByCurrentUser = false;
 
-    /**
-     * @var bool
-     */
-    private $userHasUpvoted = false;
+    private bool $userHasUpvoted = false;
 
     public function __construct()
     {
         $this->upvotes = new ArrayCollection();
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = $this->createdAt;
     }
 
     public function getId(): int
@@ -248,7 +224,7 @@ class Comment
         return $this;
     }
 
-    public function getCreatedAt(): \DateTime
+    public function getCreatedAt(): \DateTimeInterface
     {
         return $this->createdAt;
     }
@@ -260,7 +236,7 @@ class Comment
         return $this;
     }
 
-    public function getUpdatedAt(): \DateTime
+    public function getUpdatedAt(): \DateTimeInterface
     {
         return $this->updatedAt;
     }

--- a/core/src/Entity/Comment/Comment.php
+++ b/core/src/Entity/Comment/Comment.php
@@ -18,7 +18,7 @@ class Comment
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(type: 'integer')]
-    private ?int $id;
+    private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: Comment::class)]
     #[ORM\JoinColumn(nullable: true, onDelete: 'CASCADE')]

--- a/core/src/Entity/Comment/CommentUpvote.php
+++ b/core/src/Entity/Comment/CommentUpvote.php
@@ -15,7 +15,7 @@ class CommentUpvote
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(type: 'integer')]
-    private ?int $id;
+    private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: Comment::class, inversedBy: 'upvotes')]
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]

--- a/core/src/Entity/Comment/CommentUpvote.php
+++ b/core/src/Entity/Comment/CommentUpvote.php
@@ -7,60 +7,42 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="salt_comment_upvote", uniqueConstraints={@ORM\UniqueConstraint(name="comment_user", columns={"comment_id", "user_id"})})
- * @UniqueEntity(fields={"comment", "user"})
- */
+#[ORM\Entity]
+#[ORM\Table(name: 'salt_comment_upvote', uniqueConstraints: [new ORM\UniqueConstraint(name: 'comment_user', columns: ['comment_id', 'user_id'])])]
+#[UniqueEntity(fields: ['comment', 'user'])]
 class CommentUpvote
 {
-    /**
-     * @var int
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(type="integer")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id;
+
+    #[ORM\ManyToOne(targetEntity: Comment::class, inversedBy: 'upvotes')]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Comment $comment;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(nullable: false)]
+    private User $user;
 
     /**
-     * @var Comment
-     *
-     * @ORM\ManyToOne(targetEntity="Comment", inversedBy="upvotes")
-     * @ORM\JoinColumn(nullable=false, onDelete="CASCADE")
-     */
-    private $comment;
-
-    /**
-     * @var User
-     *
-     * @ORM\ManyToOne(targetEntity="App\Entity\User\User")
-     * @ORM\JoinColumn(nullable=false)
-     */
-    private $user;
-
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", precision=6)
      * @Gedmo\Timestampable(on="create")
      */
-    private $createdAt;
+    #[ORM\Column(type: 'datetime', precision: 6)]
+    private \DateTimeInterface $createdAt;
 
     /**
-     * @var \DateTime
-     *
-     * @ORM\Column(type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
-    private $updatedAt;
+    #[ORM\Column(type: 'datetime', precision: 6)]
+    private \DateTimeInterface $updatedAt;
 
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    public function setUser(User $user): CommentUpvote
+    public function setUser(User $user): static
     {
         $this->user = $user;
 
@@ -72,7 +54,7 @@ class CommentUpvote
         return $this->user;
     }
 
-    public function setComment(Comment $comment = null): CommentUpvote
+    public function setComment(Comment $comment): static
     {
         $this->comment = $comment;
 
@@ -84,26 +66,26 @@ class CommentUpvote
         return $this->comment;
     }
 
-    public function setCreatedAt(\DateTime $createdAt): CommentUpvote
+    public function setCreatedAt(\DateTimeInterface $createdAt): static
     {
         $this->createdAt = $createdAt;
 
         return $this;
     }
 
-    public function getCreatedAt(): \DateTime
+    public function getCreatedAt(): \DateTimeInterface
     {
         return $this->createdAt;
     }
 
-    public function setUpdatedAt(\DateTime $updatedAt): CommentUpvote
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): static
     {
         $this->updatedAt = $updatedAt;
 
         return $this;
     }
 
-    public function getUpdatedAt(): \DateTime
+    public function getUpdatedAt(): \DateTimeInterface
     {
         return $this->updatedAt;
     }

--- a/core/src/Entity/Framework/AbstractLsBase.php
+++ b/core/src/Entity/Framework/AbstractLsBase.php
@@ -8,50 +8,38 @@ use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\MappedSuperclass()
- */
+#[ORM\MappedSuperclass]
 class AbstractLsBase implements IdentifiableInterface
 {
-    /**
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected ?int $id = null;
 
-    /**
-     * @ORM\Column(name="identifier", type="string", length=300, nullable=false, unique=true)
-     *
-     * @Assert\NotBlank()
-     * @Assert\Uuid(strict=false)
-     * @Assert\Length(max=300)
-     */
+    #[ORM\Column(name: 'identifier', type: 'string', length: 300, unique: true, nullable: false)]
+    #[Assert\NotBlank]
+    #[Assert\Uuid(strict: false)]
+    #[Assert\Length(max: 300)]
     protected ?string $identifier = null;
 
-    /**
-     * @ORM\Column(name="uri", type="string", length=300, nullable=true, unique=true)
-     *
-     * @Assert\NotBlank()
-     * @Assert\Length(max=300)
-     */
+    #[ORM\Column(name: 'uri', type: 'string', length: 300, unique: true, nullable: true)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 300)]
     protected ?string $uri = null;
 
-    /**
-     * @ORM\Column(name="extra", type="json", nullable=true)
-     */
+    #[ORM\Column(name: 'extra', type: 'json', nullable: true)]
     protected ?array $extra = null;
 
     /**
-     * @ORM\Column(name="changed_at", type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
+    #[ORM\Column(name: 'changed_at', type: 'datetime', precision: 6)]
     private \DateTimeInterface $changedAt;
 
     /**
-     * @ORM\Column(name="updated_at", type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
+    #[ORM\Column(name: 'updated_at', type: 'datetime', precision: 6)]
     protected \DateTimeInterface $updatedAt;
 
     public function __construct(UuidInterface|string|null $identifier = null)
@@ -102,7 +90,7 @@ class AbstractLsBase implements IdentifiableInterface
         // If the identifier is in the form of a UUID then lower case it
         if ($identifier instanceof UuidInterface) {
             $identifier = strtolower($identifier->toString());
-        } elseif (is_string($identifier) && Uuid::isValid($identifier)) {
+        } elseif (Uuid::isValid($identifier)) {
             $identifier = strtolower(Uuid::fromString($identifier)->toString());
         } else {
             throw new \InvalidArgumentException('The identifier must be a UUID.');

--- a/core/src/Entity/Framework/AbstractLsDefinition.php
+++ b/core/src/Entity/Framework/AbstractLsDefinition.php
@@ -4,25 +4,16 @@ namespace App\Entity\Framework;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\MappedSuperclass()
- */
+#[ORM\MappedSuperclass]
 class AbstractLsDefinition extends AbstractLsBase
 {
-    /**
-     * @ORM\Column(name="title", type="string", length=1024, nullable=true)
-     */
+    #[ORM\Column(name: 'title', type: 'string', length: 1024, nullable: true)]
     protected ?string $title = null;
 
-    /**
-     * @ORM\Column(name="description", type="text", nullable=true)
-     */
+    #[ORM\Column(name: 'description', type: 'text', nullable: true)]
     protected ?string $description = null;
 
-    /**
-     * @return static
-     */
-    public function setTitle(?string $title)
+    public function setTitle(?string $title): static
     {
         $this->title = $title;
 
@@ -34,10 +25,7 @@ class AbstractLsDefinition extends AbstractLsBase
         return $this->title;
     }
 
-    /**
-     * @return static
-     */
-    public function setDescription(?string $description)
+    public function setDescription(?string $description): static
     {
         $this->description = $description;
 

--- a/core/src/Entity/Framework/AdditionalField.php
+++ b/core/src/Entity/Framework/AdditionalField.php
@@ -2,63 +2,45 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\AdditionalFieldRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Entity(repositoryClass="App\Repository\Framework\AdditionalFieldRepository")
- * @ORM\Table(
- *     name="salt_additional_field",
- *     indexes={
- *         @ORM\Index(name="applies_idx", columns={"applies_to"})
- *     }
- * )
- * @UniqueEntity(fields={"name"}, message="The custom field name is already used.")
- */
+#[ORM\Entity(repositoryClass: AdditionalFieldRepository::class)]
+#[ORM\Table(name: 'salt_additional_field', indexes: [new ORM\Index(name: 'applies_idx', columns: ['applies_to'])])]
+#[UniqueEntity(fields: ['name'], message: 'The custom field name is already used.')]
 class AdditionalField
 {
-    /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private ?int $id = null;
 
-    /**
-     * @ORM\Column(type="string", length=255, unique=true)
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     * @Assert\Regex(pattern="/^[a-z0-9_]+$/", message="The name may only have lower case alpha-numeric characters and underscores.")
-     * @Assert\Regex(pattern="/(^_)|(_$)|(_[^a-z])/", match=false, message="An underscore (_) must be before a letter (not a number or underscore), and must not be at the beginning of the name.")
-     * @Assert\Regex(pattern="/^[a-z]/", match=true, message="The name must start with a lower case letter.")
-     */
+    #[ORM\Column(type: 'string', length: 255, unique: true)]
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[a-z0-9_]+$/', message: 'The name may only have lower case alpha-numeric characters and underscores.')]
+    #[Assert\Regex(pattern: '/(^_)|(_$)|(_[^a-z])/', message: 'An underscore (_) must be before a letter (not a number or underscore), and must not be at the beginning of the name.', match: false)]
+    #[Assert\Regex(pattern: '/^[a-z]/', message: 'The name must start with a lower case letter.', match: true)]
     private ?string $name = null;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     */
+    #[ORM\Column(type: 'string', length: 255)]
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private ?string $appliesTo = null;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     */
+    #[ORM\Column(type: 'string', length: 255)]
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     private ?string $displayName = null;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     * @Assert\NotNull()
-     * @Assert\Choice(callback="getTypes", message="The field type is not a valid type.")
-     */
+    #[ORM\Column(type: 'string', length: 255)]
+    #[Assert\NotNull]
+    #[Assert\Choice(callback: 'getTypes', message: 'The field type is not a valid type.')]
     private ?string $type = null;
 
-    /**
-     * @ORM\Column(type="json", nullable=true)
-     */
+    #[ORM\Column(type: 'json', nullable: true)]
     private ?array $typeInfo = null;
 
     /**

--- a/core/src/Entity/Framework/AssociationSubtype.php
+++ b/core/src/Entity/Framework/AssociationSubtype.php
@@ -10,9 +10,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ORM\Entity(repositoryClass: AssociationSubtypeRepository::class)]
 class AssociationSubtype
 {
-    public const DIR_BOTH = 0;
-    public const DIR_FORWARD = 1;
-    public const DIR_INVERSE = -1;
+    final public const DIR_BOTH = 0;
+    final public const DIR_FORWARD = 1;
+    final public const DIR_INVERSE = -1;
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/core/src/Entity/Framework/AssociationSubtype.php
+++ b/core/src/Entity/Framework/AssociationSubtype.php
@@ -2,65 +2,40 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\AssociationSubtypeRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Table(name="salt_association_subtype")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\AssociationSubtypeRepository")
- */
+#[ORM\Table(name: 'salt_association_subtype')]
+#[ORM\Entity(repositoryClass: AssociationSubtypeRepository::class)]
 class AssociationSubtype
 {
     public const DIR_BOTH = 0;
     public const DIR_FORWARD = 1;
     public const DIR_INVERSE = -1;
 
-    /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private int $id;
 
-    /**
-     * @ORM\Column(type="string", length=255, unique=true)
-     *
-     * @Assert\NotBlank()
-     * @Assert\NotNull()
-     */
+    #[ORM\Column(type: 'string', length: 255, unique: true)]
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
     private string $name;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     *
-     * @Assert\NotBlank()
-     * @Assert\NotNull()
-     * @Assert\Choice({
-     *     "Is Child Of",
-     *     "Exact Match Of",
-     *     "Is Related To",
-     *     "Is Part Of",
-     *     "Replaced By",
-     *     "Precedes",
-     *     "Has Skill Level",
-     *     "Is Peer Of",
-     *     "Exemplar",
-     * })
-     */
+    #[ORM\Column(type: 'string', length: 255)]
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Choice(['Is Child Of', 'Exact Match Of', 'Is Related To', 'Is Part Of', 'Replaced By', 'Precedes', 'Has Skill Level', 'Is Peer Of', 'Exemplar'])]
     private string $parentType;
 
-    /**
-     * @ORM\Column(type="integer")
-     *
-     * @Assert\NotNull()
-     */
+    #[ORM\Column(type: 'integer')]
+    #[Assert\NotNull]
     private int $direction;
 
-    /**
-     * @ORM\Column(type="string", length=512)
-     *
-     * @Assert\NotNull()
-     */
+    #[ORM\Column(type: 'string', length: 512)]
+    #[Assert\NotNull]
     private string $description;
 
     public function getId(): int

--- a/core/src/Entity/Framework/CfRubric.php
+++ b/core/src/Entity/Framework/CfRubric.php
@@ -2,34 +2,27 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\CfRubricRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\UuidInterface;
 
-/**
- * @ORM\MappedSuperclass()
- *
- * @ORM\Table(name="rubric")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\CfRubricRepository")
- */
+#[ORM\MappedSuperclass]
+#[ORM\Table(name: 'rubric')]
+#[ORM\Entity(repositoryClass: CfRubricRepository::class)]
 class CfRubric extends AbstractLsBase implements CaseApiInterface
 {
-    /**
-     * @ORM\Column(name="title", type="text", length=65535, nullable=true)
-     */
+    #[ORM\Column(name: 'title', type: 'text', length: 65535, nullable: true)]
     private ?string $title = null;
 
-    /**
-     * @ORM\Column(name="description", type="text", length=65535, nullable=true)
-     */
+    #[ORM\Column(name: 'description', type: 'text', length: 65535, nullable: true)]
     private ?string $description = null;
 
     /**
      * @var Collection<array-key, CfRubricCriterion>
-     *
-     * @ORM\OneToMany(targetEntity="CfRubricCriterion", mappedBy="rubric", orphanRemoval=true, cascade={"persist", "remove"})
      */
+    #[ORM\OneToMany(mappedBy: 'rubric', targetEntity: CfRubricCriterion::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection $criteria;
 
     public function __construct(UuidInterface|string|null $identifier = null)
@@ -43,7 +36,7 @@ class CfRubric extends AbstractLsBase implements CaseApiInterface
         return $this->title;
     }
 
-    public function setTitle(?string $title): CfRubric
+    public function setTitle(?string $title): static
     {
         $this->title = $title;
 
@@ -55,7 +48,7 @@ class CfRubric extends AbstractLsBase implements CaseApiInterface
         return $this->description;
     }
 
-    public function setDescription(?string $description): CfRubric
+    public function setDescription(?string $description): static
     {
         $this->description = $description;
 
@@ -70,14 +63,14 @@ class CfRubric extends AbstractLsBase implements CaseApiInterface
         return $this->criteria;
     }
 
-    public function addCriterion(CfRubricCriterion $criterion): CfRubric
+    public function addCriterion(CfRubricCriterion $criterion): static
     {
         $this->criteria[] = $criterion;
 
         return $this;
     }
 
-    public function removeCriterion(CfRubricCriterion $criterion): CfRubric
+    public function removeCriterion(CfRubricCriterion $criterion): static
     {
         $this->criteria->removeElement($criterion);
 

--- a/core/src/Entity/Framework/CfRubricCriterion.php
+++ b/core/src/Entity/Framework/CfRubricCriterion.php
@@ -2,56 +2,41 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\CfRubricCriterionRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\UuidInterface;
 
-/**
- * @ORM\MappedSuperclass()
- *
- * @ORM\Table(name="rubric_criterion")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\CfRubricCriterionRepository")
- */
+#[ORM\MappedSuperclass]
+#[ORM\Table(name: 'rubric_criterion')]
+#[ORM\Entity(repositoryClass: CfRubricCriterionRepository::class)]
 class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
 {
-    /**
-     * @ORM\Column(name="category", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'category', type: 'string', nullable: true)]
     private ?string $category = null;
 
-    /**
-     * @ORM\Column(name="description", type="text", length=65535, nullable=true)
-     */
+    #[ORM\Column(name: 'description', type: 'text', length: 65535, nullable: true)]
     private ?string $description = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="LsItem", inversedBy="criteria")
-     * @ORM\JoinColumn(name="ls_item_id", referencedColumnName="id")
-     */
+    #[ORM\ManyToOne(targetEntity: LsItem::class, inversedBy: 'criteria')]
+    #[ORM\JoinColumn(name: 'ls_item_id', referencedColumnName: 'id')]
     private ?LsItem $item = null;
 
-    /**
-     * @ORM\Column(name="weight", type="float", nullable=true)
-     */
+    #[ORM\Column(name: 'weight', type: 'float', nullable: true)]
     private ?float $weight = null;
 
-    /**
-     * @ORM\Column(name="position", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'position', type: 'integer', nullable: true)]
     private ?int $position = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="CfRubric", inversedBy="criteria")
-     * @ORM\JoinColumn(name="rubric_id", referencedColumnName="id", nullable=false)
-     */
+    #[ORM\ManyToOne(targetEntity: CfRubric::class, inversedBy: 'criteria')]
+    #[ORM\JoinColumn(name: 'rubric_id', referencedColumnName: 'id', nullable: false)]
     private CfRubric $rubric;
 
     /**
      * @var Collection<array-key, CfRubricCriterionLevel>
-     *
-     * @ORM\OneToMany(targetEntity="CfRubricCriterionLevel", mappedBy="criterion", orphanRemoval=true, cascade={"persist", "remove"})
      */
+    #[ORM\OneToMany(mappedBy: 'criterion', targetEntity: CfRubricCriterionLevel::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection $levels;
 
     public function __construct(UuidInterface|string|null $identifier = null)
@@ -65,7 +50,7 @@ class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
         return $this->category;
     }
 
-    public function setCategory(?string $category): CfRubricCriterion
+    public function setCategory(?string $category): static
     {
         $this->category = $category;
 
@@ -77,7 +62,7 @@ class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
         return $this->description;
     }
 
-    public function setDescription(?string $description): CfRubricCriterion
+    public function setDescription(?string $description): static
     {
         $this->description = $description;
 
@@ -89,7 +74,7 @@ class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
         return $this->item;
     }
 
-    public function setItem(?LsItem $item): CfRubricCriterion
+    public function setItem(?LsItem $item): static
     {
         $this->item = $item;
 
@@ -101,7 +86,7 @@ class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
         return $this->weight;
     }
 
-    public function setWeight(?float $weight): CfRubricCriterion
+    public function setWeight(?float $weight): static
     {
         $this->weight = $weight;
 
@@ -113,7 +98,7 @@ class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
         return $this->position;
     }
 
-    public function setPosition(?int $position): CfRubricCriterion
+    public function setPosition(?int $position): static
     {
         $this->position = $position;
 
@@ -125,7 +110,7 @@ class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
         return $this->rubric;
     }
 
-    public function setRubric(CfRubric $rubric): CfRubricCriterion
+    public function setRubric(CfRubric $rubric): static
     {
         $this->rubric = $rubric;
 
@@ -140,14 +125,14 @@ class CfRubricCriterion extends AbstractLsBase implements CaseApiInterface
         return $this->levels;
     }
 
-    public function addLevel(CfRubricCriterionLevel $level): CfRubricCriterion
+    public function addLevel(CfRubricCriterionLevel $level): static
     {
         $this->levels[] = $level;
 
         return $this;
     }
 
-    public function removeLevel(CfRubricCriterionLevel $level): CfRubricCriterion
+    public function removeLevel(CfRubricCriterionLevel $level): static
     {
         $this->levels->removeElement($level);
 

--- a/core/src/Entity/Framework/CfRubricCriterionLevel.php
+++ b/core/src/Entity/Framework/CfRubricCriterionLevel.php
@@ -2,45 +2,31 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\CfRubricCriterionLevelRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\MappedSuperclass()
- *
- * @ORM\Table(name="rubric_criterion_level")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\CfRubricCriterionLevelRepository")
- */
+#[ORM\MappedSuperclass]
+#[ORM\Table(name: 'rubric_criterion_level')]
+#[ORM\Entity(repositoryClass: CfRubricCriterionLevelRepository::class)]
 class CfRubricCriterionLevel extends AbstractLsBase implements CaseApiInterface
 {
-    /**
-     * @ORM\Column(name="description", type="text", length=65535, nullable=true)
-     */
+    #[ORM\Column(name: 'description', type: 'text', length: 65535, nullable: true)]
     private ?string $description = null;
 
-    /**
-     * @ORM\Column(name="quality", type="text", length=65535, nullable=true)
-     */
+    #[ORM\Column(name: 'quality', type: 'text', length: 65535, nullable: true)]
     private ?string $quality = null;
 
-    /**
-     * @ORM\Column(name="score", type="float", nullable=true)
-     */
+    #[ORM\Column(name: 'score', type: 'float', nullable: true)]
     private ?float $score = null;
 
-    /**
-     * @ORM\Column(name="feedback", type="text", length=65535, nullable=true)
-     */
+    #[ORM\Column(name: 'feedback', type: 'text', length: 65535, nullable: true)]
     private ?string $feedback = null;
 
-    /**
-     * @ORM\Column(name="position", type="integer", nullable=true)
-     */
+    #[ORM\Column(name: 'position', type: 'integer', nullable: true)]
     private ?int $position = null;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="CfRubricCriterion", inversedBy="levels")
-     * @ORM\JoinColumn(name="criterion_id", referencedColumnName="id", nullable=false)
-     */
+    #[ORM\ManyToOne(targetEntity: CfRubricCriterion::class, inversedBy: 'levels')]
+    #[ORM\JoinColumn(name: 'criterion_id', referencedColumnName: 'id', nullable: false)]
     private CfRubricCriterion $criterion;
 
     public function getDescription(): ?string
@@ -48,7 +34,7 @@ class CfRubricCriterionLevel extends AbstractLsBase implements CaseApiInterface
         return $this->description;
     }
 
-    public function setDescription(?string $description): CfRubricCriterionLevel
+    public function setDescription(?string $description): static
     {
         $this->description = $description;
 
@@ -60,7 +46,7 @@ class CfRubricCriterionLevel extends AbstractLsBase implements CaseApiInterface
         return $this->quality;
     }
 
-    public function setQuality(?string $quality): CfRubricCriterionLevel
+    public function setQuality(?string $quality): static
     {
         $this->quality = $quality;
 
@@ -72,7 +58,7 @@ class CfRubricCriterionLevel extends AbstractLsBase implements CaseApiInterface
         return $this->score;
     }
 
-    public function setScore(?float $score): CfRubricCriterionLevel
+    public function setScore(?float $score): static
     {
         $this->score = $score;
 
@@ -84,7 +70,7 @@ class CfRubricCriterionLevel extends AbstractLsBase implements CaseApiInterface
         return $this->feedback;
     }
 
-    public function setFeedback(?string $feedback): CfRubricCriterionLevel
+    public function setFeedback(?string $feedback): static
     {
         $this->feedback = $feedback;
 
@@ -96,7 +82,7 @@ class CfRubricCriterionLevel extends AbstractLsBase implements CaseApiInterface
         return $this->position;
     }
 
-    public function setPosition(?int $position): CfRubricCriterionLevel
+    public function setPosition(?int $position): static
     {
         $this->position = $position;
 
@@ -108,7 +94,7 @@ class CfRubricCriterionLevel extends AbstractLsBase implements CaseApiInterface
         return $this->criterion;
     }
 
-    public function setCriterion(CfRubricCriterion $criterion): CfRubricCriterionLevel
+    public function setCriterion(CfRubricCriterion $criterion): static
     {
         $this->criterion = $criterion;
 

--- a/core/src/Entity/Framework/FrameworkType.php
+++ b/core/src/Entity/Framework/FrameworkType.php
@@ -2,25 +2,20 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\FrameworkTypeRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Table(name="framework_type")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\FrameworkTypeRepository")
- */
+#[ORM\Table(name: 'framework_type')]
+#[ORM\Entity(repositoryClass: FrameworkTypeRepository::class)]
 class FrameworkType
 {
-    /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
-     * @ORM\Column(type="integer")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
-    private $frameworkType;
+    #[ORM\Column(type: 'string', length: 255)]
+    private ?string $frameworkType;
 
     public function getId(): ?int
     {
@@ -32,10 +27,8 @@ class FrameworkType
         return $this->frameworkType;
     }
 
-    public function setFrameworkType(string $frameworkType): self
+    public function setFrameworkType(string $frameworkType): void
     {
         $this->frameworkType = $frameworkType;
-
-        return $this;
     }
 }

--- a/core/src/Entity/Framework/FrameworkType.php
+++ b/core/src/Entity/Framework/FrameworkType.php
@@ -12,10 +12,10 @@ class FrameworkType
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private ?int $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private ?string $frameworkType;
+    private ?string $frameworkType = null;
 
     public function getId(): ?int
     {

--- a/core/src/Entity/Framework/ImportLog.php
+++ b/core/src/Entity/Framework/ImportLog.php
@@ -2,140 +2,73 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\ImportLogRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * Class ImportLog
- *
- * @ORM\Entity(repositoryClass="App\Repository\Framework\ImportLogRepository")
- * @ORM\Table(name="import_logs")
- * @UniqueEntity("id")
- */
+#[ORM\Entity(repositoryClass: ImportLogRepository::class)]
+#[ORM\Table(name: 'import_logs')]
+#[UniqueEntity('id')]
 class ImportLog
 {
-    /**
-     * @var int
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(name="id", type="integer")
-     */
-    protected $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(name: 'id', type: 'integer')]
+    protected ?int $id;
 
-    /**
-     * @var LsDoc
-     *
-     * @ORM\ManyToOne(targetEntity="LsDoc", inversedBy="importLogs")
-     * @ORM\JoinColumn(name="ls_doc_id", referencedColumnName="id", nullable=false)
-     *
-     * @Assert\NotBlank()
-     */
-    protected $lsDoc;
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'importLogs')]
+    #[ORM\JoinColumn(name: 'ls_doc_id', referencedColumnName: 'id', nullable: false)]
+    #[Assert\NotBlank]
+    protected ?LsDoc $lsDoc;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="message_text", type="string", length=250)
-     *
-     * @Assert\NotBlank
-     */
-    protected $message;
+    #[ORM\Column(name: 'message_text', type: 'string', length: 250)]
+    #[Assert\NotBlank]
+    protected ?string $message;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="message_type", type="string", length=30, nullable=false)
-     */
-    protected $messageType;
+    #[ORM\Column(name: 'message_type', type: 'string', length: 30, nullable: false)]
+    protected string $messageType;
 
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="is_read", type="boolean", nullable=false, options={"default": 0})
-     */
-    protected $read = false;
+    #[ORM\Column(name: 'is_read', type: 'boolean', nullable: false, options: ['default' => 0])]
+    protected bool $read = false;
 
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->messageType = 'warning';
     }
 
-    /**
-     * Set LsDoc
-     *
-     * @param LsDoc $lsDoc
-     */
-    public function setLsDoc($lsDoc): ImportLog
+    public function setLsDoc(LsDoc $lsDoc): void
     {
         $this->lsDoc = $lsDoc;
-
-        return $this;
     }
 
-    /**
-     * Set message
-     *
-     * @param string $message
-     */
-    public function setMessage($message): ImportLog
+    public function setMessage(string $message): void
     {
         $this->message = $message;
-
-        return $this;
     }
 
-    /**
-     * Get read
-     */
     public function isRead(): bool
     {
         return $this->read;
     }
 
-    /**
-     * Get message
-     *
-     * @return string
-     */
     public function getMessage(): ?string
     {
         return $this->message;
     }
 
-    /**
-     * Set read as true
-     */
-    public function markAsRead(): ImportLog
+    public function markAsRead(): void
     {
         $this->read = true;
-
-        return $this;
     }
 
-    /**
-     * Get messageType
-     *
-     * @return string
-     */
     public function getMessageType(): ?string
     {
         return $this->messageType;
     }
 
-    /**
-     * Set messageType
-     *
-     * @param string $messageType
-     */
-    public function setMessageType($messageType): ImportLog
+    public function setMessageType(string $messageType): void
     {
         $this->messageType = $messageType;
-
-        return $this;
     }
 }

--- a/core/src/Entity/Framework/ImportLog.php
+++ b/core/src/Entity/Framework/ImportLog.php
@@ -15,16 +15,16 @@ class ImportLog
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(name: 'id', type: 'integer')]
-    protected ?int $id;
+    protected ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'importLogs')]
     #[ORM\JoinColumn(name: 'ls_doc_id', referencedColumnName: 'id', nullable: false)]
     #[Assert\NotBlank]
-    protected ?LsDoc $lsDoc;
+    protected ?LsDoc $lsDoc = null;
 
     #[ORM\Column(name: 'message_text', type: 'string', length: 250)]
     #[Assert\NotBlank]
-    protected ?string $message;
+    protected ?string $message = null;
 
     #[ORM\Column(name: 'message_type', type: 'string', length: 30, nullable: false)]
     protected string $messageType;

--- a/core/src/Entity/Framework/LsAssociation.php
+++ b/core/src/Entity/Framework/LsAssociation.php
@@ -39,7 +39,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
 
     #[ORM\Column(name: 'ls_doc_identifier', type: 'string', length: 300, nullable: false)]
     #[Assert\Length(max: 300)]
-    private ?string $lsDocIdentifier;
+    private ?string $lsDocIdentifier = null;
 
     #[ORM\Column(name: 'ls_doc_uri', type: 'string', length: 300, nullable: true)]
     #[Assert\Length(max: 300)]
@@ -55,7 +55,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
     #[ORM\Column(name: 'origin_node_identifier', type: 'string', length: 300, nullable: false)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 300)]
-    private ?string $originNodeIdentifier;
+    private ?string $originNodeIdentifier = null;
 
     #[ORM\Column(name: 'origin_node_uri', type: 'string', length: 300, nullable: true)]
     private ?string $originNodeUri = null;
@@ -71,7 +71,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
     #[ORM\Column(name: 'destination_node_identifier', type: 'string', length: 300, nullable: false)]
     #[Assert\NotBlank]
     #[Assert\Length(max: 300)]
-    private ?string $destinationNodeIdentifier;
+    private ?string $destinationNodeIdentifier = null;
 
     #[ORM\Column(name: 'destination_node_uri', type: 'string', length: 300, nullable: true)]
     private ?string $destinationNodeUri = null;
@@ -85,7 +85,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
     private ?LsItem $destinationLsItem = null;
 
     #[ORM\Column(name: 'type', type: 'string', length: 50, nullable: false)]
-    private ?string $type;
+    private ?string $type = null;
 
     #[ORM\Column(name: 'seq', type: 'bigint', nullable: true)]
     private ?int $sequenceNumber = null;

--- a/core/src/Entity/Framework/LsAssociation.php
+++ b/core/src/Entity/Framework/LsAssociation.php
@@ -317,7 +317,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
      */
     public function splitDestinationDataUri(): array
     {
-        if (0 !== strncmp($this->destinationNodeUri ?? '', 'data:text/x-', 12)) {
+        if (!str_starts_with($this->destinationNodeUri ?? '', 'data:text/x-')) {
             // Not a known data URI format, return the entire uri as the value
             return ['value' => $this->destinationNodeUri];
         }

--- a/core/src/Entity/Framework/LsAssociation.php
+++ b/core/src/Entity/Framework/LsAssociation.php
@@ -2,19 +2,13 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsAssociationRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Table(name="ls_association",
- *     indexes={
- *         @ORM\Index(name="dest_id_idx", columns={"destination_node_identifier"}),
- *         @ORM\Index(name="orig_id_idx", columns={"origin_node_identifier"}),
- *     }
- * )
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsAssociationRepository")
- */
+#[ORM\Table(name: 'ls_association', indexes: [new ORM\Index(columns: ['destination_node_identifier'], name: 'dest_id_idx'), new ORM\Index(columns: ['origin_node_identifier'], name: 'orig_id_idx')])]
+#[ORM\Entity(repositoryClass: LsAssociationRepository::class)]
 class LsAssociation extends AbstractLsBase implements CaseApiInterface
 {
     use AccessAdditionalFieldTrait;
@@ -43,137 +37,66 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
 
     public const INVERSE_EXEMPLAR = 'Exemplar For';
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ls_doc_identifier", type="string", length=300, nullable=false)
-     *
-     * @Assert\Length(max=300)
-     */
-    private $lsDocIdentifier;
+    #[ORM\Column(name: 'ls_doc_identifier', type: 'string', length: 300, nullable: false)]
+    #[Assert\Length(max: 300)]
+    private ?string $lsDocIdentifier;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ls_doc_uri", type="string", length=300, nullable=true)
-     *
-     * @Assert\Length(max=300)
-     */
-    private $lsDocUri;
+    #[ORM\Column(name: 'ls_doc_uri', type: 'string', length: 300, nullable: true)]
+    #[Assert\Length(max: 300)]
+    private ?string $lsDocUri = null;
 
-    /**
-     * @var LsDoc
-     *
-     * @ORM\ManyToOne(targetEntity="LsDoc", inversedBy="docAssociations")
-     */
-    private $lsDoc;
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'docAssociations')]
+    private ?LsDoc $lsDoc = null;
 
-    /**
-     * @var LsDefAssociationGrouping
-     *
-     * @ORM\ManyToOne(targetEntity="LsDefAssociationGrouping", fetch="EAGER")
-     * @ORM\JoinColumn(name="assoc_group_id", referencedColumnName="id")
-     */
-    private $group;
+    #[ORM\ManyToOne(targetEntity: LsDefAssociationGrouping::class, fetch: 'EAGER')]
+    #[ORM\JoinColumn(name: 'assoc_group_id', referencedColumnName: 'id')]
+    private ?LsDefAssociationGrouping $group = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="origin_node_identifier", type="string", length=300, nullable=false)
-     *
-     * @Assert\NotBlank()
-     * @Assert\Length(max=300)
-     */
-    private $originNodeIdentifier;
+    #[ORM\Column(name: 'origin_node_identifier', type: 'string', length: 300, nullable: false)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 300)]
+    private ?string $originNodeIdentifier;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="origin_node_uri", type="string", length=300, nullable=true)
-     */
-    private $originNodeUri;
+    #[ORM\Column(name: 'origin_node_uri', type: 'string', length: 300, nullable: true)]
+    private ?string $originNodeUri = null;
 
-    /**
-     * @var LsDoc
-     *
-     * @ORM\ManyToOne(targetEntity="LsDoc", inversedBy="associations", fetch="EAGER")
-     * @ORM\JoinColumn(name="origin_lsdoc_id", referencedColumnName="id", onDelete="SET NULL")
-     */
-    private $originLsDoc;
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, fetch: 'EAGER', inversedBy: 'associations')]
+    #[ORM\JoinColumn(name: 'origin_lsdoc_id', referencedColumnName: 'id', onDelete: 'SET NULL')]
+    private ?LsDoc $originLsDoc = null;
 
-    /**
-     * @var LsItem
-     *
-     * @ORM\ManyToOne(targetEntity="LsItem", inversedBy="associations", fetch="EAGER", cascade={"persist"})
-     * @ORM\JoinColumn(name="origin_lsitem_id", referencedColumnName="id", onDelete="SET NULL")
-     */
-    private $originLsItem;
+    #[ORM\ManyToOne(targetEntity: LsItem::class, cascade: ['persist'], fetch: 'EAGER', inversedBy: 'associations')]
+    #[ORM\JoinColumn(name: 'origin_lsitem_id', referencedColumnName: 'id', onDelete: 'SET NULL')]
+    private ?LsItem $originLsItem = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="destination_node_identifier", type="string", length=300, nullable=false)
-     *
-     * @Assert\NotBlank()
-     * @Assert\Length(max=300)
-     */
-    private $destinationNodeIdentifier;
+    #[ORM\Column(name: 'destination_node_identifier', type: 'string', length: 300, nullable: false)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 300)]
+    private ?string $destinationNodeIdentifier;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="destination_node_uri", type="string", length=300, nullable=true)
-     */
-    private $destinationNodeUri;
+    #[ORM\Column(name: 'destination_node_uri', type: 'string', length: 300, nullable: true)]
+    private ?string $destinationNodeUri = null;
 
-    /**
-     * @var LsDoc
-     *
-     * @ORM\ManyToOne(targetEntity="LsDoc", inversedBy="inverseAssociations", fetch="EAGER")
-     * @ORM\JoinColumn(name="destination_lsdoc_id", referencedColumnName="id", onDelete="SET NULL")
-     */
-    private $destinationLsDoc;
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, fetch: 'EAGER', inversedBy: 'inverseAssociations')]
+    #[ORM\JoinColumn(name: 'destination_lsdoc_id', referencedColumnName: 'id', onDelete: 'SET NULL')]
+    private ?LsDoc $destinationLsDoc = null;
 
-    /**
-     * @var LsItem
-     *
-     * @ORM\ManyToOne(targetEntity="LsItem", inversedBy="inverseAssociations", fetch="EAGER", cascade={"persist"})
-     * @ORM\JoinColumn(name="destination_lsitem_id", referencedColumnName="id", onDelete="SET NULL")
-     */
-    private $destinationLsItem;
+    #[ORM\ManyToOne(targetEntity: LsItem::class, cascade: ['persist'], fetch: 'EAGER', inversedBy: 'inverseAssociations')]
+    #[ORM\JoinColumn(name: 'destination_lsitem_id', referencedColumnName: 'id', onDelete: 'SET NULL')]
+    private ?LsItem $destinationLsItem = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="type", type="string", length=50, nullable=false)
-     */
-    private $type;
+    #[ORM\Column(name: 'type', type: 'string', length: 50, nullable: false)]
+    private ?string $type;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="seq", type="bigint", nullable=true)
-     */
-    private $sequenceNumber;
+    #[ORM\Column(name: 'seq', type: 'bigint', nullable: true)]
+    private ?int $sequenceNumber = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="subtype", type="string", nullable=true)
-     */
-    private $subtype;
+    #[ORM\Column(name: 'subtype', type: 'string', nullable: true)]
+    private ?string $subtype = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="annotation", type="text", length=65534, nullable=true)
-     */
-    private $annotation;
+    #[ORM\Column(name: 'annotation', type: 'text', length: 65534, nullable: true)]
+    private ?string $annotation = null;
 
-    /**
-     * @param string|UuidInterface|null $identifier
-     */
-    public function __construct($identifier = null)
+    public function __construct(UuidInterface|string|null $identifier = null)
     {
         parent::__construct($identifier);
     }
@@ -184,7 +107,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
     }
 
     /**
-     * Get all types collectted by camel case.
+     * Get all types indexed by camel case.
      */
     public static function allTypesForImportFromCSV(): array
     {
@@ -270,11 +193,9 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
     /**
      * Set the Origination of the association.
      *
-     * @param string|IdentifiableInterface $origin
-     *
      * @throws \UnexpectedValueException
      */
-    public function setOrigin($origin, ?string $identifier = null): self
+    public function setOrigin(IdentifiableInterface|string $origin, ?string $identifier = null): static
     {
         if (is_string($origin)) {
             $this->setOriginNodeUri($origin);
@@ -283,27 +204,21 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
             return $this;
         }
 
-        if ($origin instanceof IdentifiableInterface) {
-            if ($origin instanceof LsDoc) {
-                $this->setOriginLsDoc($origin);
-            } elseif ($origin instanceof LsItem) {
-                $this->setOriginLsItem($origin);
-            }
-            $this->setOriginNodeUri($origin->getUri());
-            $this->setOriginNodeIdentifier($identifier ?? $origin->getIdentifier());
-
-            return $this;
+        if ($origin instanceof LsDoc) {
+            $this->setOriginLsDoc($origin);
+        } elseif ($origin instanceof LsItem) {
+            $this->setOriginLsItem($origin);
         }
+        $this->setOriginNodeUri($origin->getUri());
+        $this->setOriginNodeIdentifier($identifier ?? $origin->getIdentifier());
 
-        throw new \UnexpectedValueException('The value must be a URI, an LsDoc, or an LsItem');
+        return $this;
     }
 
     /**
      * Get the Origination of the association.
-     *
-     * @return string|LsDoc|LsItem|null
      */
-    public function getOrigin()
+    public function getOrigin(): string|LsItem|LsDoc|null
     {
         if ($this->getOriginLsDoc()) {
             return $this->getOriginLsDoc();
@@ -320,7 +235,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return null;
     }
 
-    public function setOriginNodeUri(string $originNodeUri): self
+    public function setOriginNodeUri(string $originNodeUri): static
     {
         $this->originNodeUri = $originNodeUri;
 
@@ -335,11 +250,9 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
     /**
      * Set the Destination of the association.
      *
-     * @param string|IdentifiableInterface $destination
-     *
      * @throws \UnexpectedValueException
      */
-    public function setDestination($destination, ?string $identifier = null): self
+    public function setDestination(IdentifiableInterface|string $destination, ?string $identifier = null): static
     {
         if (is_string($destination)) {
             $this->setDestinationNodeUri($destination);
@@ -348,27 +261,21 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
             return $this;
         }
 
-        if ($destination instanceof IdentifiableInterface) {
-            if ($destination instanceof LsDoc) {
-                $this->setDestinationLsDoc($destination);
-            } elseif ($destination instanceof LsItem) {
-                $this->setDestinationLsItem($destination);
-            }
-            $this->setDestinationNodeUri($destination->getUri());
-            $this->setDestinationNodeIdentifier($identifier ?? $destination->getIdentifier());
-
-            return $this;
+        if ($destination instanceof LsDoc) {
+            $this->setDestinationLsDoc($destination);
+        } elseif ($destination instanceof LsItem) {
+            $this->setDestinationLsItem($destination);
         }
+        $this->setDestinationNodeUri($destination->getUri());
+        $this->setDestinationNodeIdentifier($identifier ?? $destination->getIdentifier());
 
-        throw new \UnexpectedValueException('The value must be a URI, an LsDoc, or an LsItem');
+        return $this;
     }
 
     /**
      * Get the Destination of the association.
-     *
-     * @return string|LsDoc|LsItem|null
      */
-    public function getDestination()
+    public function getDestination(): string|LsItem|LsDoc|null
     {
         if ($this->getDestinationLsDoc()) {
             return $this->getDestinationLsDoc();
@@ -385,7 +292,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return null;
     }
 
-    public function setDestinationNodeUri(string $destinationNodeUri): self
+    public function setDestinationNodeUri(string $destinationNodeUri): static
     {
         $this->destinationNodeUri = $destinationNodeUri;
 
@@ -410,7 +317,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
      */
     public function splitDestinationDataUri(): array
     {
-        if (0 !== strncmp($this->destinationNodeUri, 'data:text/x-', 12)) {
+        if (0 !== strncmp($this->destinationNodeUri ?? '', 'data:text/x-', 12)) {
             // Not a known data URI format, return the entire uri as the value
             return ['value' => $this->destinationNodeUri];
         }
@@ -437,7 +344,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $metadata;
     }
 
-    public function setType(?string $type): self
+    public function setType(?string $type): static
     {
         if (in_array($type, self::allTypes(), true)) {
             $this->type = $type;
@@ -485,7 +392,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return null;
     }
 
-    public function setOriginLsDoc(?LsDoc $originLsDoc = null): self
+    public function setOriginLsDoc(?LsDoc $originLsDoc = null): static
     {
         $this->originLsDoc = $originLsDoc;
 
@@ -502,7 +409,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->originLsDoc;
     }
 
-    public function setOriginLsItem(?LsItem $originLsItem = null): self
+    public function setOriginLsItem(?LsItem $originLsItem = null): static
     {
         $this->originLsItem = $originLsItem;
 
@@ -519,7 +426,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->originLsItem;
     }
 
-    public function setDestinationLsDoc(?LsDoc $destinationLsDoc = null): self
+    public function setDestinationLsDoc(?LsDoc $destinationLsDoc = null): static
     {
         $this->destinationLsDoc = $destinationLsDoc;
         if (null !== $destinationLsDoc) {
@@ -535,7 +442,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->destinationLsDoc;
     }
 
-    public function setDestinationLsItem(?LsItem $destinationLsItem = null): self
+    public function setDestinationLsItem(?LsItem $destinationLsItem = null): static
     {
         $this->destinationLsItem = $destinationLsItem;
         if (null !== $destinationLsItem) {
@@ -551,7 +458,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->destinationLsItem;
     }
 
-    public function setLsDocUri(?string $lsDocUri): self
+    public function setLsDocUri(?string $lsDocUri): static
     {
         $this->lsDocUri = $lsDocUri;
 
@@ -563,7 +470,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->lsDocUri;
     }
 
-    public function setLsDoc(LsDoc $lsDoc): self
+    public function setLsDoc(LsDoc $lsDoc): static
     {
         $this->lsDoc = $lsDoc;
         $this->setLsDocUri($lsDoc->getUri());
@@ -582,7 +489,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->lsDocIdentifier;
     }
 
-    public function setLsDocIdentifier(?string $lsDocIdentifier): self
+    public function setLsDocIdentifier(?string $lsDocIdentifier): static
     {
         $this->lsDocIdentifier = $lsDocIdentifier;
 
@@ -594,7 +501,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->originNodeIdentifier;
     }
 
-    public function setOriginNodeIdentifier(?string $originNodeIdentifier): self
+    public function setOriginNodeIdentifier(?string $originNodeIdentifier): static
     {
         $this->originNodeIdentifier = $originNodeIdentifier;
 
@@ -606,7 +513,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->destinationNodeIdentifier;
     }
 
-    public function setDestinationNodeIdentifier(?string $destinationNodeIdentifier): self
+    public function setDestinationNodeIdentifier(?string $destinationNodeIdentifier): static
     {
         $this->destinationNodeIdentifier = $destinationNodeIdentifier;
 
@@ -626,7 +533,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->sequenceNumber;
     }
 
-    public function setSequenceNumber(?int $sequenceNumber): self
+    public function setSequenceNumber(?int $sequenceNumber): static
     {
         $this->sequenceNumber = $sequenceNumber;
 
@@ -638,7 +545,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->group;
     }
 
-    public function setGroup(?LsDefAssociationGrouping $group): self
+    public function setGroup(?LsDefAssociationGrouping $group): static
     {
         $this->group = $group;
 
@@ -650,7 +557,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->subtype;
     }
 
-    public function setSubtype(?string $subtype): self
+    public function setSubtype(?string $subtype): static
     {
         $this->subtype = $subtype;
 
@@ -662,7 +569,7 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
         return $this->annotation;
     }
 
-    public function setAnnotation(?string $annotation): self
+    public function setAnnotation(?string $annotation): static
     {
         $this->annotation = $annotation;
 

--- a/core/src/Entity/Framework/LsAssociation.php
+++ b/core/src/Entity/Framework/LsAssociation.php
@@ -13,29 +13,29 @@ class LsAssociation extends AbstractLsBase implements CaseApiInterface
 {
     use AccessAdditionalFieldTrait;
 
-    public const CHILD_OF = 'Is Child Of';
+    final public const CHILD_OF = 'Is Child Of';
 
-    public const EXACT_MATCH_OF = 'Exact Match Of';
-    public const RELATED_TO = 'Is Related To';
-    public const PART_OF = 'Is Part Of';
-    public const REPLACED_BY = 'Replaced By';
-    public const PRECEDES = 'Precedes';
-    public const SKILL_LEVEL = 'Has Skill Level';
-    public const IS_PEER_OF = 'Is Peer Of';
+    final public const EXACT_MATCH_OF = 'Exact Match Of';
+    final public const RELATED_TO = 'Is Related To';
+    final public const PART_OF = 'Is Part Of';
+    final public const REPLACED_BY = 'Replaced By';
+    final public const PRECEDES = 'Precedes';
+    final public const SKILL_LEVEL = 'Has Skill Level';
+    final public const IS_PEER_OF = 'Is Peer Of';
 
-    public const EXEMPLAR = 'Exemplar';
+    final public const EXEMPLAR = 'Exemplar';
 
-    public const INVERSE_CHILD_OF = 'Is Parent Of';
+    final public const INVERSE_CHILD_OF = 'Is Parent Of';
 
-    public const INVERSE_EXACT_MATCH_OF = 'Matched From';
-    public const INVERSE_RELATED_TO = 'Related From';
-    public const INVERSE_PART_OF = 'Has Part';
-    public const INVERSE_REPLACED_BY = 'Replaces';
-    public const INVERSE_PRECEDES = 'Has Predecessor';
-    public const INVERSE_SKILL_LEVEL = 'Skill Level For';
-    public const INVERSE_IS_PEER_OF = 'Peer Of';
+    final public const INVERSE_EXACT_MATCH_OF = 'Matched From';
+    final public const INVERSE_RELATED_TO = 'Related From';
+    final public const INVERSE_PART_OF = 'Has Part';
+    final public const INVERSE_REPLACED_BY = 'Replaces';
+    final public const INVERSE_PRECEDES = 'Has Predecessor';
+    final public const INVERSE_SKILL_LEVEL = 'Skill Level For';
+    final public const INVERSE_IS_PEER_OF = 'Peer Of';
 
-    public const INVERSE_EXEMPLAR = 'Exemplar For';
+    final public const INVERSE_EXEMPLAR = 'Exemplar For';
 
     #[ORM\Column(name: 'ls_doc_identifier', type: 'string', length: 300, nullable: false)]
     #[Assert\Length(max: 300)]

--- a/core/src/Entity/Framework/LsDefAssociationGrouping.php
+++ b/core/src/Entity/Framework/LsDefAssociationGrouping.php
@@ -2,48 +2,32 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsDefAssociationGroupingRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Table(name="ls_def_association_grouping")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDefAssociationGroupingRepository")
- */
+#[ORM\Table(name: 'ls_def_association_grouping')]
+#[ORM\Entity(repositoryClass: LsDefAssociationGroupingRepository::class)]
 class LsDefAssociationGrouping extends AbstractLsDefinition implements CaseApiInterface
 {
-    /**
-     * @var LsDoc
-     *
-     * @ORM\ManyToOne(targetEntity="LsDoc", inversedBy="associationGroupings")
-     *
-     * @Assert\NotNull()
-     */
-    private $lsDoc;
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'associationGroupings')]
+    #[Assert\NotNull]
+    private ?LsDoc $lsDoc;
 
-    /**
-     * @return LsDoc
-     */
     public function getLsDoc(): ?LsDoc
     {
         return $this->lsDoc;
     }
 
-    /**
-     * @param LsDoc $lsDoc
-     *
-     * @return LsDefAssociationGrouping
-     */
-    public function setLsDoc(?LsDoc $lsDoc)
+    public function setLsDoc(?LsDoc $lsDoc): void
     {
         $this->lsDoc = $lsDoc;
-
-        return $this;
     }
 
     /**
      * Create a duplicate of the lsDefAssociationGrouping into a new document.
      */
-    public function duplicateToLsDoc(LsDoc $newLsDoc): LsDefAssociationGrouping
+    public function duplicateToLsDoc(LsDoc $newLsDoc): static
     {
         $newAssociationGrouping = clone $this;
         $newAssociationGrouping->setLsDoc($newLsDoc);

--- a/core/src/Entity/Framework/LsDefAssociationGrouping.php
+++ b/core/src/Entity/Framework/LsDefAssociationGrouping.php
@@ -12,7 +12,7 @@ class LsDefAssociationGrouping extends AbstractLsDefinition implements CaseApiIn
 {
     #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'associationGroupings')]
     #[Assert\NotNull]
-    private ?LsDoc $lsDoc;
+    private ?LsDoc $lsDoc = null;
 
     public function getLsDoc(): ?LsDoc
     {

--- a/core/src/Entity/Framework/LsDefConcept.php
+++ b/core/src/Entity/Framework/LsDefConcept.php
@@ -2,26 +2,17 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsDefConceptRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * LsDefConcept.
- *
- * @ORM\Table(name="ls_def_concept")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDefConceptRepository")
- */
+#[ORM\Table(name: 'ls_def_concept')]
+#[ORM\Entity(repositoryClass: LsDefConceptRepository::class)]
 class LsDefConcept extends AbstractLsDefinition implements CaseApiInterface
 {
-    /**
-     * @ORM\Column(name="hierarchy_code", type="string", length=255)
-     */
+    #[ORM\Column(name: 'hierarchy_code', type: 'string', length: 255)]
     private string $hierarchyCode;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="keywords", type="text", nullable=true)
-     */
+    #[ORM\Column(name: 'keywords', type: 'text', nullable: true)]
     private ?string $keywords = null;
 
     public function getHierarchyCode(): string
@@ -29,11 +20,9 @@ class LsDefConcept extends AbstractLsDefinition implements CaseApiInterface
         return $this->hierarchyCode;
     }
 
-    public function setHierarchyCode(string $hierarchyCode): LsDefConcept
+    public function setHierarchyCode(string $hierarchyCode): void
     {
         $this->hierarchyCode = $hierarchyCode;
-
-        return $this;
     }
 
     public function getKeywords(): ?string
@@ -41,11 +30,9 @@ class LsDefConcept extends AbstractLsDefinition implements CaseApiInterface
         return $this->keywords;
     }
 
-    public function setKeywords(?string $keywords): LsDefConcept
+    public function setKeywords(?string $keywords): void
     {
         $this->keywords = $keywords;
-
-        return $this;
     }
 
     /**

--- a/core/src/Entity/Framework/LsDefGrade.php
+++ b/core/src/Entity/Framework/LsDefGrade.php
@@ -2,71 +2,40 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsDefGradeRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * LsDefGrade
- *
- * @ORM\Table(name="ls_def_grade")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDefGradeRepository")
- */
+#[ORM\Table(name: 'ls_def_grade')]
+#[ORM\Entity(repositoryClass: LsDefGradeRepository::class)]
 class LsDefGrade extends AbstractLsDefinition
 {
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="code", type="string", length=255)
-     */
-    private $code;
+    #[ORM\Column(name: 'code', type: 'string', length: 255)]
+    private string $code;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="rank", type="integer", nullable=true)
-     */
-    private $rank;
+    #[ORM\Column(name: 'rank', type: 'integer', nullable: true)]
+    private int $rank;
 
-    /**
-     * @return string
-     */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->code;
     }
 
-    /**
-     * @param string $code
-     *
-     * @return LsDefGrade
-     */
-    public function setCode($code)
+    public function setCode(string $code): void
     {
         $this->code = $code;
-
-        return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getRank()
+    public function getRank(): int
     {
         return $this->rank;
     }
 
-    /**
-     * @param int $rank
-     *
-     * @return LsDefGrade
-     */
-    public function setRank($rank)
+    public function setRank(int $rank): void
     {
         $this->rank = $rank;
-
-        return $this;
     }
 
-    public function getLabel()
+    public function getLabel(): string
     {
         return "{$this->getCode()} - {$this->getTitle()}";
     }

--- a/core/src/Entity/Framework/LsDefItemType.php
+++ b/core/src/Entity/Framework/LsDefItemType.php
@@ -2,40 +2,27 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsDefItemTypeRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * LsDefItemType
- *
- * @ORM\Table(name="ls_def_item_type")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDefItemTypeRepository")
- */
+#[ORM\Table(name: 'ls_def_item_type')]
+#[ORM\Entity(repositoryClass: LsDefItemTypeRepository::class)]
 class LsDefItemType extends AbstractLsDefinition implements CaseApiInterface
 {
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="code", type="string", length=255, nullable=true)
-     */
-    private $code;
+    #[ORM\Column(name: 'code', type: 'string', length: 255, nullable: true)]
+    private ?string $code = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="hierarchy_code", type="string", length=255)
-     */
-    private $hierarchyCode;
+    #[ORM\Column(name: 'hierarchy_code', type: 'string', length: 255)]
+    private string $hierarchyCode;
 
     public function getCode(): ?string
     {
         return $this->code;
     }
 
-    public function setCode(?string $code): LsDefItemType
+    public function setCode(?string $code): void
     {
         $this->code = $code;
-
-        return $this;
     }
 
     public function getHierarchyCode(): string
@@ -43,11 +30,9 @@ class LsDefItemType extends AbstractLsDefinition implements CaseApiInterface
         return $this->hierarchyCode;
     }
 
-    public function setHierarchyCode(string $hierarchyCode): LsDefItemType
+    public function setHierarchyCode(string $hierarchyCode): void
     {
         $this->hierarchyCode = $hierarchyCode;
-
-        return $this;
     }
 
     public function __toString(): string

--- a/core/src/Entity/Framework/LsDefLicence.php
+++ b/core/src/Entity/Framework/LsDefLicence.php
@@ -2,40 +2,23 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsDefLicenceRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * LsDefLicence
- *
- * @ORM\Table(name="ls_def_licence")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDefLicenceRepository")
- */
+#[ORM\Table(name: 'ls_def_licence')]
+#[ORM\Entity(repositoryClass: LsDefLicenceRepository::class)]
 class LsDefLicence extends AbstractLsDefinition implements CaseApiInterface
 {
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="licence_text", type="text")
-     */
-    private $licenceText;
+    #[ORM\Column(name: 'licence_text', type: 'text')]
+    private string $licenceText;
 
-    /**
-     * @return string
-     */
-    public function getLicenceText()
+    public function getLicenceText(): string
     {
         return $this->licenceText;
     }
 
-    /**
-     * @param string $licenceText
-     *
-     * @return LsDefLicence
-     */
-    public function setLicenceText($licenceText)
+    public function setLicenceText(string $licenceText): void
     {
         $this->licenceText = $licenceText;
-
-        return $this;
     }
 }

--- a/core/src/Entity/Framework/LsDefSubject.php
+++ b/core/src/Entity/Framework/LsDefSubject.php
@@ -2,31 +2,24 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsDefSubjectRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Table(name="ls_def_subject")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDefSubjectRepository")
- */
+#[ORM\Table(name: 'ls_def_subject')]
+#[ORM\Entity(repositoryClass: LsDefSubjectRepository::class)]
 class LsDefSubject extends AbstractLsDefinition implements CaseApiInterface
 {
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="hierarchy_code", type="string", length=255)
-     */
-    private $hierarchyCode;
+    #[ORM\Column(name: 'hierarchy_code', type: 'string', length: 255)]
+    private string $hierarchyCode;
 
     public function getHierarchyCode(): string
     {
         return $this->hierarchyCode;
     }
 
-    public function setHierarchyCode(string $hierarchyCode): LsDefSubject
+    public function setHierarchyCode(string $hierarchyCode): void
     {
         $this->hierarchyCode = $hierarchyCode;
-
-        return $this;
     }
 
     public function __toString(): string

--- a/core/src/Entity/Framework/LsDoc.php
+++ b/core/src/Entity/Framework/LsDoc.php
@@ -82,7 +82,9 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
      * @var Collection<array-key, LsDefSubject>
      */
     #[ORM\ManyToMany(targetEntity: LsDefSubject::class)]
-    #[ORM\JoinTable(name: 'ls_doc_subject', joinColumns: [new ORM\JoinColumn(name: 'ls_doc_id', referencedColumnName: 'id')], inverseJoinColumns: [new ORM\JoinColumn(name: 'subject_id', referencedColumnName: 'id')])]
+    #[ORM\JoinTable(name: 'ls_doc_subject')]
+    #[ORM\JoinColumn(name: 'ls_doc_id', referencedColumnName: 'id')]
+    #[ORM\InverseJoinColumn(name: 'subject_id', referencedColumnName: 'id')]
     #[Assert\All([new Assert\Type(LsDefSubject::class)])]
     private Collection $subjects;
 

--- a/core/src/Entity/Framework/LsDoc.php
+++ b/core/src/Entity/Framework/LsDoc.php
@@ -23,10 +23,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[UniqueEntity('identifier')]
 class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterface
 {
-    public const ADOPTION_STATUS_PRIVATE_DRAFT = 'Private Draft';
-    public const ADOPTION_STATUS_DRAFT = 'Draft';
-    public const ADOPTION_STATUS_ADOPTED = 'Adopted';
-    public const ADOPTION_STATUS_DEPRECATED = 'Deprecated';
+    final public const ADOPTION_STATUS_PRIVATE_DRAFT = 'Private Draft';
+    final public const ADOPTION_STATUS_DRAFT = 'Draft';
+    final public const ADOPTION_STATUS_ADOPTED = 'Adopted';
+    final public const ADOPTION_STATUS_DEPRECATED = 'Deprecated';
 
     #[ORM\ManyToOne(targetEntity: Organization::class, inversedBy: 'frameworks')]
     #[ORM\JoinColumn(name: 'org_id', referencedColumnName: 'id', nullable: true)]

--- a/core/src/Entity/Framework/LsDoc.php
+++ b/core/src/Entity/Framework/LsDoc.php
@@ -335,9 +335,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
             $subject = [$subject];
         }
 
-        if (array_reduce($subject, static function ($carry, $el): bool {
-            return $carry || !\is_string($el);
-        }, false)) {
+        if (array_reduce($subject, static fn ($carry, $el): bool => $carry || !\is_string($el), false)) {
             throw new \InvalidArgumentException('setSubject must be passed an array of strings.');
         }
 
@@ -482,18 +480,14 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
 
         Compare::sortArrayByFields($topAssociations, ['sequenceNumber', 'enum', 'hcs']);
 
-        $orderedList = array_map(static function ($rec): LsItem {
-            return $rec['item'];
-        }, $topAssociations);
+        $orderedList = array_map(static fn ($rec): LsItem => $rec['item'], $topAssociations);
 
         return new ArrayCollection($orderedList);
     }
 
     public function getTopLsItemIds(): array
     {
-        return $this->getTopLsItems()->map(static function (LsItem $item): ?int {
-            return $item->getId();
-        })->toArray();
+        return $this->getTopLsItems()->map(static fn (LsItem $item): ?int => $item->getId())->toArray();
     }
 
     public function addLsItem(LsItem $lsItem): static

--- a/core/src/Entity/Framework/LsDoc.php
+++ b/core/src/Entity/Framework/LsDoc.php
@@ -7,6 +7,7 @@ use App\Entity\LockableInterface;
 use App\Entity\User\Organization;
 use App\Entity\User\User;
 use App\Entity\User\UserDocAcl;
+use App\Repository\Framework\LsDocRepository;
 use App\Util\Compare;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -15,13 +16,11 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Table(name="ls_doc")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDocRepository")
- * @UniqueEntity("uri")
- * @UniqueEntity("urlName")
- * @UniqueEntity("identifier")
- */
+#[ORM\Table(name: 'ls_doc')]
+#[ORM\Entity(repositoryClass: LsDocRepository::class)]
+#[UniqueEntity('uri')]
+#[UniqueEntity('urlName')]
+#[UniqueEntity('identifier')]
 class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterface
 {
     public const ADOPTION_STATUS_PRIVATE_DRAFT = 'Private Draft';
@@ -29,285 +28,153 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     public const ADOPTION_STATUS_ADOPTED = 'Adopted';
     public const ADOPTION_STATUS_DEPRECATED = 'Deprecated';
 
-    /**
-     * @var Organization|null
-     *
-     * @ORM\ManyToOne(targetEntity="App\Entity\User\Organization", inversedBy="frameworks")
-     * @ORM\JoinColumn(name="org_id", referencedColumnName="id", nullable=true)
-     *
-     * @Assert\Type(Organization::class)
-     */
-    protected $org;
+    #[ORM\ManyToOne(targetEntity: Organization::class, inversedBy: 'frameworks')]
+    #[ORM\JoinColumn(name: 'org_id', referencedColumnName: 'id', nullable: true)]
+    #[Assert\Type(Organization::class)]
+    protected ?Organization $org = null;
 
-    /**
-     * @var User|null
-     *
-     * @ORM\ManyToOne(targetEntity="App\Entity\User\User", inversedBy="frameworks")
-     * @ORM\JoinColumn(name="user_id", referencedColumnName="id", nullable=true)
-     *
-     * @Assert\Type(User::class)
-     */
-    protected $user;
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'frameworks')]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true)]
+    #[Assert\Type(User::class)]
+    protected ?User $user = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="official_uri", type="string", length=300, nullable=true)
-     *
-     * @Assert\Length(max=300)
-     * @Assert\Url()
-     */
-    private $officialUri;
+    #[ORM\Column(name: 'official_uri', type: 'string', length: 300, nullable: true)]
+    #[Assert\Length(max: 300)]
+    #[Assert\Url]
+    private ?string $officialUri = null;
 
-    /**
-     * @var ?string
-     *
-     * @ORM\Column(name="creator", type="string", length=300, nullable=false)
-     *
-     * @Assert\NotBlank()
-     * @Assert\Length(max=300)
-     */
-    private $creator;
+    #[ORM\Column(name: 'creator', type: 'string', length: 300, nullable: false)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 300)]
+    private ?string $creator = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="publisher", type="string", length=50, nullable=true)
-     *
-     * @Assert\Length(max=50)
-     */
-    private $publisher;
+    #[ORM\Column(name: 'publisher', type: 'string', length: 50, nullable: true)]
+    #[Assert\Length(max: 50)]
+    private ?string $publisher = null;
 
-    /**
-     * @var ?string
-     *
-     * @ORM\Column(name="title", type="string", length=120, nullable=false)
-     *
-     * @Assert\NotBlank()
-     * @Assert\Length(max=120)
-     */
-    private $title;
+    #[ORM\Column(name: 'title', type: 'string', length: 120, nullable: false)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 120)]
+    private ?string $title = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="url_name", type="string", length=255, nullable=true, unique=true)
-     *
-     * @Assert\Length(max=10)
-     * @Assert\Regex(
-     *     pattern="/^\d+$/",
-     *     match=false,
-     *     message="The URL Name cannot be a number."
-     * )
-     * @Assert\Regex(
-     *     pattern="/^[a-zA-Z0-9.-]+$/",
-     *     message="The URL Name can only use alpha-numeric characters plus a period (.) or dash (-)."
-     * )
-     */
-    private $urlName;
+    #[ORM\Column(name: 'url_name', type: 'string', length: 255, unique: true, nullable: true)]
+    #[Assert\Length(max: 10)]
+    #[Assert\Regex(pattern: '/^\d+$/', message: 'The URL Name cannot be a number.', match: false)]
+    #[Assert\Regex(pattern: '/^[a-zA-Z0-9.-]+$/', message: 'The URL Name can only use alpha-numeric characters plus a period (.) or dash (-).')]
+    private ?string $urlName = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="version", type="string", length=50, nullable=true)
-     *
-     * @Assert\Length(max=50)
-     */
-    private $version;
+    #[ORM\Column(name: 'version', type: 'string', length: 50, nullable: true)]
+    #[Assert\Length(max: 50)]
+    private ?string $version = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="description", type="string", length=300, nullable=true)
-     *
-     * @Assert\Length(max=300)
-     */
-    private $description;
+    #[ORM\Column(name: 'description', type: 'string', length: 300, nullable: true)]
+    #[Assert\Length(max: 300)]
+    private ?string $description = null;
 
     /**
      * @var string[]|null
-     *
-     * @ORM\Column(name="subject", type="json", nullable=true)
-     *
-     * @Assert\All({
-     *     @Assert\Type("string")
-     * })
      */
-    private $subject = [];
+    #[ORM\Column(name: 'subject', type: 'json', nullable: true)]
+    #[Assert\All([new Assert\Type('string')])]
+    private ?array $subject = [];
 
     /**
-     * @var LsDefSubject[]|Collection
-     *
-     * @ORM\ManyToMany(targetEntity="LsDefSubject")
-     * @ORM\JoinTable(name="ls_doc_subject",
-     *      joinColumns={@ORM\JoinColumn(name="ls_doc_id", referencedColumnName="id")},
-     *      inverseJoinColumns={@ORM\JoinColumn(name="subject_id", referencedColumnName="id")}
-     * )
-     *
-     * @Assert\All({
-     *     @Assert\Type(LsDefSubject::class)
-     * })
+     * @var Collection<array-key, LsDefSubject>
      */
-    private $subjects;
+    #[ORM\ManyToMany(targetEntity: LsDefSubject::class)]
+    #[ORM\JoinTable(name: 'ls_doc_subject', joinColumns: [new ORM\JoinColumn(name: 'ls_doc_id', referencedColumnName: 'id')], inverseJoinColumns: [new ORM\JoinColumn(name: 'subject_id', referencedColumnName: 'id')])]
+    #[Assert\All([new Assert\Type(LsDefSubject::class)])]
+    private Collection $subjects;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="language", type="string", length=10, nullable=true)
-     *
-     * @Assert\Length(max=10)
-     */
-    private $language;
+    #[ORM\Column(name: 'language', type: 'string', length: 10, nullable: true)]
+    #[Assert\Length(max: 10)]
+    private ?string $language = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="adoption_status", type="string", length=50, nullable=true)
-     *
-     * @Assert\Length(max=50)
-     * @Assert\Choice(callback = "getStatuses")
-     */
-    private $adoptionStatus;
+    #[ORM\Column(name: 'adoption_status', type: 'string', length: 50, nullable: true)]
+    #[Assert\Length(max: 50)]
+    #[Assert\Choice(callback: 'getStatuses')]
+    private ?string $adoptionStatus = null;
 
-    /**
-     * @ORM\Column(name="status_start", type="date", nullable=true)
-     */
+    #[ORM\Column(name: 'status_start', type: 'date', nullable: true)]
     private ?\DateTimeInterface $statusStart = null;
 
-    /**
-     * @ORM\Column(name="status_end", type="date", nullable=true)
-     */
+    #[ORM\Column(name: 'status_end', type: 'date', nullable: true)]
     private ?\DateTimeInterface $statusEnd = null;
 
-    /**
-     * @var LsDefLicence|null
-     *
-     * @ORM\ManyToOne(targetEntity="LsDefLicence")
-     * @ORM\JoinColumn(name="licence_id", referencedColumnName="id", nullable=true)
-     */
-    private $licence;
+    #[ORM\ManyToOne(targetEntity: LsDefLicence::class)]
+    #[ORM\JoinColumn(name: 'licence_id', referencedColumnName: 'id', nullable: true)]
+    private ?LsDefLicence $licence = null;
+
+    #[ORM\ManyToOne(targetEntity: FrameworkType::class, cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'frameworktype_id', referencedColumnName: 'id', nullable: true)]
+    private ?FrameworkType $frameworkType = null;
+
+    #[ORM\Column(name: 'note', type: 'text', nullable: true)]
+    private ?string $note = null;
 
     /**
-     * @var FrameworkType|null
-     *
-     * @ORM\ManyToOne(targetEntity="FrameworkType", cascade = {"persist"})
-     * @ORM\JoinColumn(name="frameworktype_id", referencedColumnName="id", nullable=true)
+     * @var Collection<array-key, LsItem>
      */
-    private $frameworkType;
-
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="note", type="text", nullable=true)
-     */
-    private $note;
-
-    /**
-     * @var Collection|LsItem[]
-     *
-     * @ORM\OneToMany(targetEntity="LsItem", mappedBy="lsDoc", indexBy="id", fetch="EXTRA_LAZY")
-     *
-     * @Assert\All({
-     *     @Assert\Type(LsItem::class)
-     * })
-     */
-    private $lsItems;
-
-    /**
-     * @var Collection|LsAssociation[]
-     *
-     * @ORM\OneToMany(targetEntity="LsAssociation", mappedBy="lsDoc", indexBy="id", fetch="EXTRA_LAZY")
-     *
-     * @Assert\All({
-     *     @Assert\Type(LsAssociation::class)
-     * })
-     */
-    private $docAssociations;
-
-    /**
-     * @var Collection|LsAssociation[]
-     *
-     * @Assert\All({
-     *     @Assert\Type(LsAssociation::class)
-     * })
-     *
-     * @ORM\OneToMany(targetEntity="LsAssociation", mappedBy="originLsDoc", indexBy="id", cascade={"persist"})
-     */
-    private $associations;
+    #[ORM\OneToMany(mappedBy: 'lsDoc', targetEntity: LsItem::class, fetch: 'EXTRA_LAZY', indexBy: 'id')]
+    #[Assert\All([new Assert\Type(LsItem::class)])]
+    private Collection $lsItems;
 
     /**
      * @var Collection<array-key, LsAssociation>
-     *
-     * @Assert\All({
-     *     @Assert\Type(LsAssociation::class)
-     * })
-     *
-     * @ORM\OneToMany(targetEntity="LsAssociation", mappedBy="destinationLsDoc", indexBy="id", cascade={"persist"})
      */
-    private $inverseAssociations;
+    #[ORM\OneToMany(mappedBy: 'lsDoc', targetEntity: LsAssociation::class, fetch: 'EXTRA_LAZY', indexBy: 'id')]
+    #[Assert\All([new Assert\Type(LsAssociation::class)])]
+    private Collection $docAssociations;
 
     /**
-     * @var LsDocAttribute[]|ArrayCollection
-     *
-     * @Assert\All({
-     *     @Assert\Type(LsDocAttribute::class)
-     * })
-     *
-     * @ORM\OneToMany(targetEntity="LsDocAttribute", mappedBy="lsDoc", cascade={"ALL"}, indexBy="attribute", orphanRemoval=true)
+     * @var Collection<array-key, LsAssociation>
      */
-    private $attributes;
+    #[Assert\All([new Assert\Type(LsAssociation::class)])]
+    #[ORM\OneToMany(mappedBy: 'originLsDoc', targetEntity: LsAssociation::class, cascade: ['persist'], indexBy: 'id')]
+    private Collection $associations;
 
     /**
-     * @var UserDocAcl[]|Collection
-     *
-     * @ORM\OneToMany(targetEntity="App\Entity\User\UserDocAcl", mappedBy="lsDoc", indexBy="user", fetch="EXTRA_LAZY")
-     *
-     * @Assert\All({
-     *     @Assert\Type(UserDocAcl::class)
-     * })
+     * @var Collection<array-key, LsAssociation>
      */
-    protected $docAcls;
+    #[Assert\All([new Assert\Type(LsAssociation::class)])]
+    #[ORM\OneToMany(mappedBy: 'destinationLsDoc', targetEntity: LsAssociation::class, cascade: ['persist'], indexBy: 'id')]
+    private Collection $inverseAssociations;
 
     /**
-     * @var ImportLog[]|Collection
-     *
-     * @ORM\OneToMany(targetEntity="ImportLog", mappedBy="lsDoc", indexBy="lsDoc", fetch="EXTRA_LAZY")
-     *
-     * @Assert\All({
-     *     @Assert\Type(ImportLog::class)
-     * })
+     * @var Collection<array-key, LsDocAttribute>
      */
-    protected $importLogs;
+    #[Assert\All([new Assert\Type(LsDocAttribute::class)])]
+    #[ORM\OneToMany(mappedBy: 'lsDoc', targetEntity: LsDocAttribute::class, cascade: ['ALL'], orphanRemoval: true, indexBy: 'attribute')]
+    private Collection $attributes;
 
     /**
-     * @var LsDefAssociationGrouping[]|Collection
-     *
-     * @ORM\OneToMany(targetEntity="LsDefAssociationGrouping", mappedBy="lsDoc", indexBy="id", fetch="EXTRA_LAZY")
-     *
-     * @Assert\All({
-     *     @Assert\Type(LsDefAssociationGrouping::class)
-     * })
+     * @var Collection<array-key, UserDocAcl>
      */
-    protected $associationGroupings;
+    #[ORM\OneToMany(mappedBy: 'lsDoc', targetEntity: UserDocAcl::class, fetch: 'EXTRA_LAZY', indexBy: 'user')]
+    #[Assert\All([new Assert\Type(UserDocAcl::class)])]
+    protected Collection $docAcls;
 
     /**
-     * @var ?string
-     *
-     * @Assert\Choice({"organization", "user"})
+     * @var Collection<array-key, ImportLog>
      */
-    protected $ownedBy;
+    #[ORM\OneToMany(mappedBy: 'lsDoc', targetEntity: ImportLog::class, fetch: 'EXTRA_LAZY', indexBy: 'lsDoc')]
+    #[Assert\All([new Assert\Type(ImportLog::class)])]
+    protected Collection $importLogs;
 
     /**
-     * @var ?Framework
-     *
-     * @ORM\OneToOne(targetEntity="App\Entity\Framework\Mirror\Framework", inversedBy="framework")
+     * @var Collection<array-key, LsDefAssociationGrouping>
      */
-    private $mirroredFramework;
+    #[ORM\OneToMany(mappedBy: 'lsDoc', targetEntity: LsDefAssociationGrouping::class, fetch: 'EXTRA_LAZY', indexBy: 'id')]
+    #[Assert\All([new Assert\Type(LsDefAssociationGrouping::class)])]
+    protected Collection $associationGroupings;
 
-    /**
-     * @param string|UuidInterface|null $identifier
-     */
-    public function __construct($identifier = null)
+    #[Assert\Choice(['organization', 'user'])]
+    protected ?string $ownedBy = null;
+
+    #[ORM\OneToOne(inversedBy: 'framework', targetEntity: Framework::class)]
+    private ?Framework $mirroredFramework = null;
+
+    public function __construct(UuidInterface|string|null $identifier = null)
     {
         parent::__construct($identifier);
 
@@ -370,7 +237,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->adoptionStatus === static::ADOPTION_STATUS_DEPRECATED;
     }
 
-    public function setOfficialUri(?string $officialUri): LsDoc
+    public function setOfficialUri(?string $officialUri): static
     {
         $this->officialUri = $officialUri;
 
@@ -382,7 +249,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->officialUri;
     }
 
-    public function setCreator(?string $creator): LsDoc
+    public function setCreator(?string $creator): static
     {
         $this->creator = $creator;
 
@@ -394,7 +261,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->creator;
     }
 
-    public function setPublisher(?string $publisher): LsDoc
+    public function setPublisher(?string $publisher): static
     {
         $this->publisher = $publisher;
 
@@ -406,7 +273,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->publisher;
     }
 
-    public function setTitle(string $title): LsDoc
+    public function setTitle(string $title): static
     {
         $this->title = mb_substr($title, 0, 120);
 
@@ -420,10 +287,10 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
 
     public function getShortStatement(): string
     {
-        return mb_substr($this->title, 0, 60);
+        return mb_substr($this->title ?? 'Unknown', 0, 60);
     }
 
-    public function setVersion(?string $version): LsDoc
+    public function setVersion(?string $version): static
     {
         $this->version = $version;
 
@@ -435,7 +302,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->version;
     }
 
-    public function setDescription(?string $description): LsDoc
+    public function setDescription(?string $description): static
     {
         if (null === $description) {
             $this->description = null;
@@ -456,7 +323,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     /**
      * @param string|string[]|null $subject
      */
-    public function setSubject(array|string|null $subject): LsDoc
+    public function setSubject(array|string|null $subject): static
     {
         if (null === $subject) {
             $this->subject = null;
@@ -468,9 +335,9 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
             $subject = [$subject];
         }
 
-        if ([] !== array_filter($subject, static function ($el) {
-            return !is_string($el);
-        })) {
+        if (array_reduce($subject, static function ($carry, $el): bool {
+            return $carry || !\is_string($el);
+        }, false)) {
             throw new \InvalidArgumentException('setSubject must be passed an array of strings.');
         }
 
@@ -490,7 +357,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     /**
      * @throws \InvalidArgumentException
      */
-    public function setAdoptionStatus(?string $adoptionStatus, ?string $default = null): LsDoc
+    public function setAdoptionStatus(?string $adoptionStatus, ?string $default = null): static
     {
         if (null === $adoptionStatus && null === $default) {
             $this->adoptionStatus = null;
@@ -523,7 +390,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->adoptionStatus;
     }
 
-    public function setStatusStart(?\DateTimeInterface $statusStart): LsDoc
+    public function setStatusStart(?\DateTimeInterface $statusStart): static
     {
         $this->statusStart = $statusStart;
 
@@ -535,7 +402,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->statusStart;
     }
 
-    public function setStatusEnd(?\DateTimeInterface $statusEnd): LsDoc
+    public function setStatusEnd(?\DateTimeInterface $statusEnd): static
     {
         $this->statusEnd = $statusEnd;
 
@@ -547,7 +414,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->statusEnd;
     }
 
-    public function setNote(?string $note): LsDoc
+    public function setNote(?string $note): static
     {
         $this->note = $note;
 
@@ -580,7 +447,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $association;
     }
 
-    public function addTopLsItem(LsItem $topLsItem, ?LsDefAssociationGrouping $assocGroup = null, ?int $sequenceNumber = null): LsDoc
+    public function addTopLsItem(LsItem $topLsItem, ?LsDefAssociationGrouping $assocGroup = null, ?int $sequenceNumber = null): static
     {
         $this->createChildItem($topLsItem, $assocGroup, $sequenceNumber);
 
@@ -629,7 +496,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         })->toArray();
     }
 
-    public function addLsItem(LsItem $lsItem): LsDoc
+    public function addLsItem(LsItem $lsItem): static
     {
         $this->lsItems[] = $lsItem;
 
@@ -642,14 +509,14 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     }
 
     /**
-     * @return Collection|LsItem[]
+     * @return Collection<array-key, LsItem>
      */
     public function getLsItems(): Collection
     {
         return $this->lsItems;
     }
 
-    public function addAssociation(LsAssociation $association): LsDoc
+    public function addAssociation(LsAssociation $association): static
     {
         $this->associations[] = $association;
 
@@ -662,14 +529,14 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     }
 
     /**
-     * @return Collection|LsAssociation[]
+     * @return Collection<array-key, LsAssociation>
      */
     public function getAssociations(): Collection
     {
         return $this->associations;
     }
 
-    public function addInverseAssociation(LsAssociation $inverseAssociation): LsDoc
+    public function addInverseAssociation(LsAssociation $inverseAssociation): static
     {
         $this->inverseAssociations[] = $inverseAssociation;
 
@@ -686,7 +553,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->inverseAssociations;
     }
 
-    public function addDocAssociation(LsAssociation $docAssociation): LsDoc
+    public function addDocAssociation(LsAssociation $docAssociation): static
     {
         $this->docAssociations[] = $docAssociation;
 
@@ -699,7 +566,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     }
 
     /**
-     * @return LsAssociation[]|Collection
+     * @return Collection<array-key, LsAssociation>
      */
     public function getDocAssociations(): Collection
     {
@@ -708,14 +575,12 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
 
     /**
      * Add a document attribute.
-     *
-     * @param string $name
-     * @param string $value
      */
-    public function setAttribute($name, $value): LsDoc
+    public function setAttribute(string $name, ?string $value): static
     {
         // if attribute already exists, update it
         if ($this->attributes->containsKey($name)) {
+            /* @noinspection NullPointerExceptionInspection -- containsKey guarantees the key exists */
             $this->attributes->get($name)->setValue($value);
         } else {
             $this->attributes->set($name, new LsDocAttribute($this, $name, $value));
@@ -724,10 +589,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this;
     }
 
-    /**
-     * @param string|int $name
-     */
-    public function removeAttribute($name): LsDoc
+    public function removeAttribute(string $name): static
     {
         // TODO (PW): does this really remove the item? I did add "orphanRemoval=true" to the attributes field above
         $this->attributes->remove($name);
@@ -735,12 +597,10 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this;
     }
 
-    /**
-     * @param string $name
-     */
-    public function getAttribute($name): ?string
+    public function getAttribute(string $name): ?string
     {
         if ($this->attributes->containsKey($name)) {
+            /* @noinspection NullPointerExceptionInspection -- containsKey guarantees the key exists */
             return $this->attributes->get($name)->getValue();
         }
 
@@ -752,7 +612,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->mirroredFramework;
     }
 
-    public function setMirroredFramework(?Framework $mirroredFramework): LsDoc
+    public function setMirroredFramework(?Framework $mirroredFramework): static
     {
         $this->mirroredFramework = $mirroredFramework;
 
@@ -762,10 +622,8 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     /**
      * Use attributes fields to save the identifiers, urls, and titles of a list of associated documents on different servers
      * Note that this fn is protected; addExternalDoc and removeExternalDoc are the public functions.
-     *
-     * @param array $externalDocs
      */
-    protected function setExternalDocs($externalDocs): LsDoc
+    protected function setExternalDocs(array $externalDocs): static
     {
         // save all ed's passed in
         $i = 0;
@@ -790,7 +648,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
      * Add an associated doc.
      *
      * @param string $identifier
-     * @param string $autoLoad - "true" or "false"
+     * @param string $autoLoad   - "true" or "false"
      * @param string $url
      * @param string $title
      */
@@ -843,7 +701,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
 
         $attrKeys = $this->attributes->getKeys();
         foreach ($attrKeys as $key) {
-            if (0 === strpos($key, 'externalDoc')) {
+            if (str_starts_with($key, 'externalDoc')) {
                 $ed = $this->getAttribute($key);
 
                 if (null !== $ed && preg_match("/^(.+?)\|(true|false)\|(.+?)\|(.*)/", $ed, $matches)) {
@@ -864,7 +722,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->language;
     }
 
-    public function setLanguage(?string $language): LsDoc
+    public function setLanguage(?string $language): static
     {
         $this->language = $language;
 
@@ -882,7 +740,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     }
 
     /**
-     * @return LsDefSubject[]|Collection
+     * @return Collection<array-key, LsDefSubject>
      */
     public function getSubjects(): Collection
     {
@@ -890,9 +748,9 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     }
 
     /**
-     * @param LsDefSubject[]|Collection $subjects
+     * @psalm-param ?iterable<array-key, LsDefSubject> $subjects
      */
-    public function setSubjects(?iterable $subjects): LsDoc
+    public function setSubjects(?iterable $subjects): static
     {
         $this->subjects = new ArrayCollection();
 
@@ -907,7 +765,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this;
     }
 
-    public function addSubject(LsDefSubject $subject): LsDoc
+    public function addSubject(LsDefSubject $subject): static
     {
         $this->subjects[] = $subject;
 
@@ -925,7 +783,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     /**
      * Set the organization owner for the framework.
      */
-    public function setOrg(?Organization $org = null): LsDoc
+    public function setOrg(?Organization $org = null): static
     {
         $this->org = $org;
 
@@ -943,7 +801,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     /**
      * Set the user owner for the framework.
      */
-    public function setUser(?User $user = null): LsDoc
+    public function setUser(?User $user = null): static
     {
         $this->user = $user;
 
@@ -952,15 +810,12 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
 
     public function getOwner(): User|Organization|null
     {
-        if (null !== $this->org) {
-            return $this->org;
-        }
-
-        return $this->user;
+        /* @noinspection ProperNullCoalescingOperatorUsageInspection */
+        return $this->org ?? $this->user;
     }
 
     /**
-     * @return Collection|ArrayCollection|UserDocAcl[]
+     * @return Collection<array-key, UserDocAcl>
      */
     public function getDocAcls(): Collection
     {
@@ -968,7 +823,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     }
 
     /**
-     * @return Collection|ArrayCollection|ImportLog[]
+     * @return Collection<array-key, ImportLog>
      */
     public function getImportLogs(): Collection
     {
@@ -998,7 +853,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     /**
      * @throws \InvalidArgumentException
      */
-    public function setOwnedBy(?string $ownedBy): LsDoc
+    public function setOwnedBy(?string $ownedBy): static
     {
         if (!in_array($ownedBy, [null, 'organization', 'user'], true)) {
             throw new \InvalidArgumentException('Owner must be "organization" or "user" (or empty)');
@@ -1010,14 +865,14 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
     }
 
     /**
-     * @return LsDefAssociationGrouping[]|Collection
+     * @return Collection<array-key, LsDefAssociationGrouping>
      */
     public function getAssociationGroupings(): Collection
     {
         return $this->associationGroupings;
     }
 
-    public function addAssociationGrouping(LsDefAssociationGrouping $associationGrouping): LsDoc
+    public function addAssociationGrouping(LsDefAssociationGrouping $associationGrouping): static
     {
         $this->associationGroupings[] = $associationGrouping;
 
@@ -1029,7 +884,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->urlName;
     }
 
-    public function setUrlName(?string $urlName = null): LsDoc
+    public function setUrlName(?string $urlName = null): static
     {
         $this->urlName = $urlName;
 
@@ -1038,11 +893,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
 
     public function getSlug(): string
     {
-        if (null !== $this->urlName) {
-            return $this->getUrlName();
-        }
-
-        return (string) $this->getId();
+        return $this->getUrlName() ?? (string) $this->getId();
     }
 
     public function getLicence(): ?LsDefLicence
@@ -1050,7 +901,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->licence;
     }
 
-    public function setLicence(?LsDefLicence $licence): LsDoc
+    public function setLicence(?LsDefLicence $licence): static
     {
         $this->licence = $licence;
 
@@ -1062,17 +913,14 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $this->frameworkType;
     }
 
-    public function setFrameworkType(?FrameworkType $frameworkType): LsDoc
+    public function setFrameworkType(?FrameworkType $frameworkType): static
     {
         $this->frameworkType = $frameworkType;
 
         return $this;
     }
 
-    /**
-     * @param UuidInterface|string|null $identifier
-     */
-    public function createItem($identifier = null): LsItem
+    public function createItem(UuidInterface|string|null $identifier = null): LsItem
     {
         $item = new LsItem($identifier);
         $item->setLsDoc($this);
@@ -1080,10 +928,7 @@ class LsDoc extends AbstractLsBase implements CaseApiInterface, LockableInterfac
         return $item;
     }
 
-    /**
-     * @param UuidInterface|string|null $identifier
-     */
-    public function createAssociation($identifier = null): LsAssociation
+    public function createAssociation(UuidInterface|string|null $identifier = null): LsAssociation
     {
         $association = new LsAssociation($identifier);
         $association->setLsDoc($this);

--- a/core/src/Entity/Framework/LsDocAttribute.php
+++ b/core/src/Entity/Framework/LsDocAttribute.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: LsDocAttributeRepository::class)]
 class LsDocAttribute
 {
-    public const IS_GRADE_LEVELS = 'isGradeLevels';
+    final public const IS_GRADE_LEVELS = 'isGradeLevels';
 
     #[ORM\Id]
     #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'attributes')]

--- a/core/src/Entity/Framework/LsDocAttribute.php
+++ b/core/src/Entity/Framework/LsDocAttribute.php
@@ -2,100 +2,58 @@
 
 namespace App\Entity\Framework;
 
+use App\Repository\Framework\LsDocAttributeRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * LsDocAttribute
- *
- * @ORM\Table(name="ls_doc_attribute")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsDocAttributeRepository")
- */
+#[ORM\Table(name: 'ls_doc_attribute')]
+#[ORM\Entity(repositoryClass: LsDocAttributeRepository::class)]
 class LsDocAttribute
 {
     public const IS_GRADE_LEVELS = 'isGradeLevels';
 
-    /**
-     * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="LsDoc", inversedBy="attributes")
-     */
-    private $lsDoc;
+    #[ORM\Id]
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'attributes')]
+    private LsDoc $lsDoc;
 
-    /**
-     * @var string
-     *
-     * @ORM\Id
-     * @ORM\Column(name="attribute", type="string", length=255)
-     */
-    private $attribute;
+    #[ORM\Id]
+    #[ORM\Column(name: 'attribute', type: 'string', length: 255)]
+    private string $attribute;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="value", type="string", length=255, nullable=true)
-     */
-    private $value;
+    #[ORM\Column(name: 'value', type: 'string', length: 255, nullable: true)]
+    private ?string $value;
 
-    public function __construct($lsDoc, $attribute, $value)
+    public function __construct(LsDoc $lsDoc, string $attribute, ?string $value)
     {
         $this->lsDoc = $lsDoc;
         $this->attribute = $attribute;
         $this->value = $value;
     }
 
-    /**
-     * Get lsDoc
-     *
-     * @return LsDoc
-     */
-    public function getLsDoc()
+    public function getLsDoc(): LsDoc
     {
         return $this->lsDoc;
     }
 
-    /**
-     * Set attribute
-     *
-     * @param string $attribute
-     *
-     * @return LsDocAttribute
-     */
-    public function setAttribute($attribute)
+    public function setAttribute(string $attribute): static
     {
         $this->attribute = $attribute;
 
         return $this;
     }
 
-    /**
-     * Get attribute
-     *
-     * @return string
-     */
-    public function getAttribute()
+    public function getAttribute(): string
     {
         return $this->attribute;
     }
 
-    /**
-     * Set value
-     *
-     * @param string $value
-     *
-     * @return LsDocAttribute
-     */
-    public function setValue($value)
+    public function setValue(?string $value): static
     {
         $this->value = $value;
 
         return $this;
     }
 
-    /**
-     * Get value
-     *
-     * @return string
-     */
-    public function getValue()
+    public function getValue(): ?string
     {
         return $this->value;
     }

--- a/core/src/Entity/Framework/LsItem.php
+++ b/core/src/Entity/Framework/LsItem.php
@@ -58,7 +58,9 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
      * @var Collection<array-key, LsDefConcept>
      */
     #[ORM\ManyToMany(targetEntity: LsDefConcept::class)]
-    #[ORM\JoinTable(name: 'ls_item_concept', joinColumns: [new ORM\JoinColumn(name: 'ls_item_id', referencedColumnName: 'id')], inverseJoinColumns: [new ORM\JoinColumn(name: 'concept_id', referencedColumnName: 'id')])]
+    #[ORM\JoinTable(name: 'ls_item_concept')]
+    #[ORM\JoinColumn(name: 'ls_item_id', referencedColumnName: 'id')]
+    #[ORM\InverseJoinColumn(name: 'concept_id', referencedColumnName: 'id')]
     private Collection $concepts;
 
     #[ORM\Column(name: 'notes', type: 'text', nullable: true)]

--- a/core/src/Entity/Framework/LsItem.php
+++ b/core/src/Entity/Framework/LsItem.php
@@ -3,6 +3,7 @@
 namespace App\Entity\Framework;
 
 use App\Entity\LockableInterface;
+use App\Repository\Framework\LsItemRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -10,193 +11,107 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Table(name="ls_item")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\LsItemRepository")
- * @UniqueEntity("uri")
- */
+#[ORM\Table(name: 'ls_item')]
+#[ORM\Entity(repositoryClass: LsItemRepository::class)]
+#[UniqueEntity('uri')]
 class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterface
 {
     use AccessAdditionalFieldTrait;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="ls_doc_identifier", type="string", length=300, nullable=false)
-     *
-     * @Assert\NotBlank()
-     * @Assert\Length(max=300)
-     */
-    private $lsDocIdentifier;
+    #[ORM\Column(name: 'ls_doc_identifier', type: 'string', length: 300, nullable: false)]
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 300)]
+    private string $lsDocIdentifier;
+
+    #[ORM\Column(name: 'ls_doc_uri', type: 'string', length: 300, nullable: true)]
+    #[Assert\Length(max: 300)]
+    private ?string $lsDocUri = null;
+
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, inversedBy: 'lsItems')]
+    #[Assert\NotBlank]
+    private LsDoc $lsDoc;
+
+    #[ORM\Column(name: 'human_coding_scheme', type: 'string', length: 50, nullable: true)]
+    #[Assert\Length(max: 50)]
+    private ?string $humanCodingScheme = null;
+
+    #[ORM\Column(name: 'list_enum_in_source', type: 'string', length: 20, nullable: true)]
+    #[Assert\Length(max: 20)]
+    private ?string $listEnumInSource = null;
+
+    #[ORM\Column(name: 'full_statement', type: 'text', nullable: false)]
+    #[Assert\NotBlank]
+    private string $fullStatement;
+
+    #[ORM\Column(name: 'abbreviated_statement', type: 'text', nullable: true)]
+    #[Assert\Length(max: 60)]
+    private ?string $abbreviatedStatement = null;
 
     /**
-     * @var string|null
-     *
-     * @ORM\Column(name="ls_doc_uri", type="string", length=300, nullable=true)
-     * @Assert\Length(max=300)
+     * @var string[]|null
      */
-    private $lsDocUri;
+    #[ORM\Column(name: 'concept_keywords', type: 'json', nullable: true)]
+    #[Assert\All([new Assert\Type('string')])]
+    private ?array $conceptKeywords = [];
 
     /**
-     * @var LsDoc
-     *
-     * @ORM\ManyToOne(targetEntity="LsDoc", inversedBy="lsItems")
-     * @Assert\NotBlank()
+     * @var Collection<array-key, LsDefConcept>
      */
-    private $lsDoc;
+    #[ORM\ManyToMany(targetEntity: LsDefConcept::class)]
+    #[ORM\JoinTable(name: 'ls_item_concept', joinColumns: [new ORM\JoinColumn(name: 'ls_item_id', referencedColumnName: 'id')], inverseJoinColumns: [new ORM\JoinColumn(name: 'concept_id', referencedColumnName: 'id')])]
+    private Collection $concepts;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="human_coding_scheme", type="string", length=50, nullable=true)
-     *
-     * @Assert\Length(max=50)
-     */
-    private $humanCodingScheme;
+    #[ORM\Column(name: 'notes', type: 'text', nullable: true)]
+    private ?string $notes = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="list_enum_in_source", type="string", length=20, nullable=true)
-     *
-     * @Assert\Length(max=20)
-     */
-    private $listEnumInSource;
+    #[ORM\Column(name: 'language', type: 'string', length: 10, nullable: true)]
+    #[Assert\Length(max: 10)]
+    private ?string $language = null;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="full_statement", type="text", nullable=false)
-     *
-     * @Assert\NotBlank()
-     */
-    private $fullStatement;
+    #[ORM\Column(name: 'educational_alignment', type: 'string', length: 300, nullable: true)]
+    #[Assert\Length(max: 300)]
+    private ?string $educationalAlignment = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="abbreviated_statement", type="text", nullable=true)
-     *
-     * @Assert\Length(max=60)
-     */
-    private $abbreviatedStatement;
+    #[ORM\ManyToOne(targetEntity: LsDefItemType::class)]
+    #[ORM\JoinColumn(name: 'item_type_id', referencedColumnName: 'id')]
+    private ?LsDefItemType $itemType = null;
 
-    /**
-     * @var array
-     *
-     * @ORM\Column(name="concept_keywords", type="json", nullable=true)
-     *
-     * @Assert\All({
-     *     @Assert\Type("string")
-     * })
-     */
-    private $conceptKeywords = [];
+    #[ORM\Column(name: 'item_type_text', type: 'string', nullable: true)]
+    #[Assert\Length(max: 255)]
+    private ?string $itemTypeText = null;
 
-    /**
-     * @var LsDefConcept[]|Collection
-     *
-     * @ORM\ManyToMany(targetEntity="LsDefConcept")
-     * @ORM\JoinTable(name="ls_item_concept",
-     *      joinColumns={@ORM\JoinColumn(name="ls_item_id", referencedColumnName="id")},
-     *      inverseJoinColumns={@ORM\JoinColumn(name="concept_id", referencedColumnName="id")}
-     * )
-     */
-    private $concepts;
+    #[ORM\Column(name: 'alternative_label', type: 'text', nullable: true)]
+    private ?string $alternativeLabel = null;
 
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="notes", type="text", nullable=true)
-     */
-    private $notes;
-
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="language", type="string", length=10, nullable=true)
-     *
-     * @Assert\Length(max=10)
-     */
-    private $language;
-
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="educational_alignment", type="string", length=300, nullable=true)
-     *
-     * @Assert\Length(max=300)
-     */
-    private $educationalAlignment;
-
-    /**
-     * @var LsDefItemType|null
-     *
-     * @ORM\ManyToOne(targetEntity="LsDefItemType")
-     * @ORM\JoinColumn(name="item_type_id", referencedColumnName="id")
-     */
-    private $itemType;
-
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="item_type_text", type="string", nullable=true)
-     *
-     * @Assert\Length(max=255)
-     */
-    private $itemTypeText;
-
-    /**
-     * @var string|null
-     *
-     * @ORM\Column(name="alternative_label", type="text", nullable=true)
-     */
-    private $alternativeLabel;
-
-    /**
-     * @ORM\Column(name="status_start", type="date", nullable=true)
-     */
+    #[ORM\Column(name: 'status_start', type: 'date', nullable: true)]
     private ?\DateTimeInterface $statusStart = null;
 
-    /**
-     * @ORM\Column(name="status_end", type="date", nullable=true)
-     */
+    #[ORM\Column(name: 'status_end', type: 'date', nullable: true)]
     private ?\DateTimeInterface $statusEnd = null;
 
-    /**
-     * @var LsDefLicence|null
-     *
-     * @ORM\ManyToOne(targetEntity="LsDefLicence")
-     * @ORM\JoinColumn(name="licence_id", referencedColumnName="id", nullable=true)
-     */
-    private $licence;
+    #[ORM\ManyToOne(targetEntity: LsDefLicence::class)]
+    #[ORM\JoinColumn(name: 'licence_id', referencedColumnName: 'id', nullable: true)]
+    private ?LsDefLicence $licence = null;
 
     /**
-     * @var Collection|LsAssociation[]
-     *
-     * @ORM\OneToMany(targetEntity="LsAssociation", mappedBy="originLsItem", indexBy="id", cascade={"persist"})
+     * @var Collection<array-key, LsAssociation>
      */
-    private $associations;
+    #[ORM\OneToMany(mappedBy: 'originLsItem', targetEntity: LsAssociation::class, cascade: ['persist'], indexBy: 'id')]
+    private Collection $associations;
 
     /**
-     * @var Collection|LsAssociation[]
-     *
-     * @ORM\OneToMany(targetEntity="LsAssociation", mappedBy="destinationLsItem", indexBy="id", cascade={"persist"})
+     * @var Collection<array-key, LsAssociation>
      */
-    private $inverseAssociations;
+    #[ORM\OneToMany(mappedBy: 'destinationLsItem', targetEntity: LsAssociation::class, cascade: ['persist'], indexBy: 'id')]
+    private Collection $inverseAssociations;
 
     /**
-     * @var Collection|CfRubricCriterion[]
-     *
-     * @ORM\OneToMany(targetEntity="CfRubricCriterion", mappedBy="item")
+     * @var Collection<array-key, CfRubricCriterion>
      */
-    private $criteria;
+    #[ORM\OneToMany(mappedBy: 'item', targetEntity: CfRubricCriterion::class)]
+    private Collection $criteria;
 
-    /**
-     * LsItem constructor.
-     *
-     * @param string|UuidInterface|null $identifier
-     */
-    public function __construct($identifier = null)
+    public function __construct(UuidInterface|string|null $identifier = null)
     {
         parent::__construct($identifier);
 
@@ -231,7 +146,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
      *
      * @throws \UnexpectedValueException
      */
-    public function copyToLsDoc(LsDoc $newLsDoc, ?LsDefAssociationGrouping $assocGroup = null, bool $exactMatchAssocs = true): LsItem
+    public function copyToLsDoc(LsDoc $newLsDoc, ?LsDefAssociationGrouping $assocGroup = null, bool $exactMatchAssocs = true): static
     {
         $newItem = clone $this;
 
@@ -267,7 +182,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
      *
      * @throws \UnexpectedValueException
      */
-    public function duplicateToLsDoc(LsDoc $newLsDoc, ?LsDefAssociationGrouping $assocGroup = null): LsItem
+    public function duplicateToLsDoc(LsDoc $newLsDoc, ?LsDefAssociationGrouping $assocGroup = null): static
     {
         $newItem = clone $this;
         $newItem->setLsDoc($newLsDoc);
@@ -292,18 +207,12 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $newItem;
     }
 
-    /**
-     * @param UuidInterface|string|null $identifier
-     */
-    public function createItem($identifier = null): LsItem
+    public function createItem(UuidInterface|string|null $identifier = null): LsItem
     {
         return $this->getLsDoc()->createItem($identifier);
     }
 
-    /**
-     * @param UuidInterface|string|null $identifier
-     */
-    public function createAssociation($identifier = null): LsAssociation
+    public function createAssociation(UuidInterface|string|null $identifier = null): LsAssociation
     {
         return $this->getLsDoc()->createAssociation($identifier);
     }
@@ -392,14 +301,10 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
      */
     public function getShortStatement(): string
     {
-        if (null !== $this->abbreviatedStatement) {
-            return $this->getAbbreviatedStatement();
-        }
-
-        return mb_substr($this->getFullStatement(), 0, 60);
+        return $this->getAbbreviatedStatement() ?? mb_substr($this->getFullStatement() ?? 'Unknown', 0, 60);
     }
 
-    public function setLsDocUri(?string $lsDocUri): LsItem
+    public function setLsDocUri(?string $lsDocUri): static
     {
         $this->lsDocUri = $lsDocUri;
 
@@ -411,7 +316,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->lsDocUri;
     }
 
-    public function setHumanCodingScheme(?string $humanCodingScheme): LsItem
+    public function setHumanCodingScheme(?string $humanCodingScheme): static
     {
         $this->humanCodingScheme = $humanCodingScheme;
 
@@ -423,7 +328,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->humanCodingScheme;
     }
 
-    public function setListEnumInSource(?string $listEnumInSource): LsItem
+    public function setListEnumInSource(?string $listEnumInSource): static
     {
         $this->listEnumInSource = $listEnumInSource;
 
@@ -435,7 +340,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->listEnumInSource;
     }
 
-    public function setFullStatement(string $fullStatement): LsItem
+    public function setFullStatement(string $fullStatement): static
     {
         $this->fullStatement = $fullStatement;
 
@@ -447,7 +352,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->fullStatement;
     }
 
-    public function setAbbreviatedStatement(?string $abbreviatedStatement): LsItem
+    public function setAbbreviatedStatement(?string $abbreviatedStatement): static
     {
         $this->abbreviatedStatement = $abbreviatedStatement;
 
@@ -462,15 +367,15 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     /**
      * @param string[]|null $conceptKeywords
      */
-    public function setConceptKeywordsArray(?array $conceptKeywords): LsItem
+    public function setConceptKeywordsArray(?array $conceptKeywords): static
     {
         if (null === $conceptKeywords) {
             $conceptKeywords = [];
         }
 
-        if ([] !== array_filter($conceptKeywords, static function ($el) {
-            return !\is_string($el);
-        })) {
+        if (array_reduce($conceptKeywords, static function ($carry, $el): bool {
+            return $carry || !\is_string($el);
+        }, false)) {
             throw new \InvalidArgumentException('setConceptKeywords must be passed an array of strings.');
         }
 
@@ -487,7 +392,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     /**
      * @deprecated Migrate to using setConceptKeywordsArray()
      */
-    public function setConceptKeywords(?string $conceptKeywords): LsItem
+    public function setConceptKeywords(?string $conceptKeywords): static
     {
         return $this->setConceptKeywordsString($conceptKeywords);
     }
@@ -500,7 +405,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->getConceptKeywordsString();
     }
 
-    public function setConceptKeywordsString(?string $conceptKeywords): LsItem
+    public function setConceptKeywordsString(?string $conceptKeywords): static
     {
         if (null === $conceptKeywords) {
             $conceptKeywords = '';
@@ -532,7 +437,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $concepts->first()->getUri();
     }
 
-    public function setNotes(?string $notes): LsItem
+    public function setNotes(?string $notes): static
     {
         $this->notes = $notes;
 
@@ -547,7 +452,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     /**
      * @param string|string[]|null $educationalAlignment
      */
-    public function setEducationalAlignment($educationalAlignment): LsItem
+    public function setEducationalAlignment(array|string|null $educationalAlignment): static
     {
         if (null === $educationalAlignment) {
             $this->educationalAlignment = null;
@@ -565,9 +470,9 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
             throw new \InvalidArgumentException('setEducationalAlignment must be passed a string or an array of strings.');
         }
 
-        if ([] !== array_filter($educationalAlignment, static function ($el) {
-            return !is_string($el);
-        })) {
+        if (array_reduce($educationalAlignment, static function ($carry, $el): bool {
+            return $carry || !\is_string($el);
+        }, false)) {
             throw new \InvalidArgumentException('setEducationalAlignment must be passed a string or an array of strings.');
         }
 
@@ -596,7 +501,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
      *
      * @throws \UnexpectedValueException
      */
-    public function addChild(LsItem $child, ?LsDefAssociationGrouping $assocGroup = null, ?int $sequenceNumber = null): LsItem
+    public function addChild(LsItem $child, ?LsDefAssociationGrouping $assocGroup = null, ?int $sequenceNumber = null): static
     {
         $association = new LsAssociation();
         $association->setLsDoc($child->getLsDoc());
@@ -619,7 +524,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @return Collection|LsItem[]
+     * @return Collection<array-key, LsItem>
      */
     public function getChildren(): Collection
     {
@@ -638,12 +543,12 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @return array|int[]
+     * @return array<array-key, int>
      */
     public function getChildIds(): array
     {
         $ids = $this->getChildren()->map(
-            static function (LsItem $item) {
+            static function (LsItem $item): int {
                 return $item->getId();
             }
         );
@@ -667,7 +572,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $childIds;
     }
 
-    public function setLsDoc(LsDoc $lsDoc): LsItem
+    public function setLsDoc(LsDoc $lsDoc): static
     {
         $this->lsDoc = $lsDoc;
         $this->lsDocUri = $lsDoc->getUri();
@@ -682,7 +587,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @return Collection|LsItem[]
+     * @return Collection<array-key, LsItem>
      */
     public function getLsItemParent(): Collection
     {
@@ -701,14 +606,14 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $parents;
     }
 
-    public function addAssociation(LsAssociation $association): LsItem
+    public function addAssociation(LsAssociation $association): static
     {
         $this->associations[] = $association;
 
         return $this;
     }
 
-    public function removeAssociation(LsAssociation $association): LsItem
+    public function removeAssociation(LsAssociation $association): static
     {
         $this->associations->removeElement($association);
 
@@ -716,21 +621,21 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @return Collection|LsAssociation[]
+     * @return Collection<array-key, LsAssociation>
      */
     public function getAssociations(): Collection
     {
         return $this->associations;
     }
 
-    public function addInverseAssociation(LsAssociation $inverseAssociation): LsItem
+    public function addInverseAssociation(LsAssociation $inverseAssociation): static
     {
         $this->inverseAssociations[] = $inverseAssociation;
 
         return $this;
     }
 
-    public function removeInverseAssociation(LsAssociation $inverseAssociation): LsItem
+    public function removeInverseAssociation(LsAssociation $inverseAssociation): static
     {
         $this->inverseAssociations->removeElement($inverseAssociation);
 
@@ -738,7 +643,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @return Collection|LsAssociation[]
+     * @return Collection<array-key, LsAssociation>
      */
     public function getInverseAssociations(): Collection
     {
@@ -778,7 +683,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->lsDocIdentifier;
     }
 
-    public function setLsDocIdentifier(?string $lsDocIdentifier): LsItem
+    public function setLsDocIdentifier(?string $lsDocIdentifier): static
     {
         $this->lsDocIdentifier = $lsDocIdentifier;
 
@@ -786,17 +691,15 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @param LsItem|LsDoc $parent
-     *
      * @throws \UnexpectedValueException
      */
-    public function addParent($parent, ?int $sequenceNumber = null, ?LsDefAssociationGrouping $assocGroup = null): LsAssociation
+    public function addParent(LsItem|LsDoc $parent, ?int $sequenceNumber = null, ?LsDefAssociationGrouping $assocGroup = null): LsAssociation
     {
         $association = new LsAssociation();
         $association->setLsDoc($this->getLsDoc());
         $association->setOrigin($this);
         $association->setType(LsAssociation::CHILD_OF);
-        $association->setDestination($parent ?: $this->lsDoc);
+        $association->setDestination($parent);
 
         // set sequenceNumber if provided
         if (null !== $sequenceNumber) {
@@ -819,7 +722,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->language;
     }
 
-    public function setLanguage(?string $language): LsItem
+    public function setLanguage(?string $language): static
     {
         $this->language = $language;
 
@@ -859,7 +762,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->itemType;
     }
 
-    public function setItemType(?LsDefItemType $itemType): LsItem
+    public function setItemType(?LsDefItemType $itemType): static
     {
         $this->itemType = $itemType;
 
@@ -871,7 +774,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->itemTypeText;
     }
 
-    public function setItemTypeText(?string $itemTypeText): LsItem
+    public function setItemTypeText(?string $itemTypeText): static
     {
         $this->itemTypeText = $itemTypeText;
 
@@ -879,7 +782,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @return LsDefConcept[]|Collection
+     * @return Collection<array-key, LsDefConcept>
      */
     public function getConcepts()
     {
@@ -887,9 +790,9 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @param LsDefConcept[]|Collection|null $concepts
+     * @psalm-param ?iterable<array-key, LsDefConcept> $concepts
      */
-    public function setConcepts(?iterable $concepts): LsItem
+    public function setConcepts(?iterable $concepts): static
     {
         $this->concepts = new ArrayCollection();
 
@@ -904,7 +807,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this;
     }
 
-    public function addConcept(LsDefConcept $concept): LsItem
+    public function addConcept(LsDefConcept $concept): static
     {
         $this->concepts[] = $concept;
 
@@ -916,7 +819,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->alternativeLabel;
     }
 
-    public function setAlternativeLabel(?string $alternativeLabel): LsItem
+    public function setAlternativeLabel(?string $alternativeLabel): static
     {
         $this->alternativeLabel = $alternativeLabel;
 
@@ -932,7 +835,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->statusStart;
     }
 
-    public function setStatusStart(?\DateTimeInterface $statusStart): LsItem
+    public function setStatusStart(?\DateTimeInterface $statusStart): static
     {
         $this->statusStart = $statusStart;
 
@@ -948,7 +851,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->statusEnd;
     }
 
-    public function setStatusEnd(?\DateTimeInterface $statusEnd): LsItem
+    public function setStatusEnd(?\DateTimeInterface $statusEnd): static
     {
         $this->statusEnd = $statusEnd;
 
@@ -960,7 +863,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
         return $this->licence;
     }
 
-    public function setLicence(?LsDefLicence $licence): LsItem
+    public function setLicence(?LsDefLicence $licence): static
     {
         $this->licence = $licence;
 
@@ -968,14 +871,14 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @return CfRubricCriterion[]|Collection
+     * @return Collection<array-key, CfRubricCriterion>
      */
     public function getCriteria(): Collection
     {
         return $this->criteria;
     }
 
-    public function addCriterion(CfRubricCriterion $criterion): LsItem
+    public function addCriterion(CfRubricCriterion $criterion): static
     {
         $this->criteria[] = $criterion;
 
@@ -983,9 +886,9 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     }
 
     /**
-     * @param CfRubricCriterion[]|Collection|null $criteria
+     * @psalm-param ?iterable<array-key, CfRubricCriterion> $criteria
      */
-    public function setCriteria(?iterable $criteria): LsItem
+    public function setCriteria(?iterable $criteria): static
     {
         $this->criteria = new ArrayCollection();
 

--- a/core/src/Entity/Framework/LsItem.php
+++ b/core/src/Entity/Framework/LsItem.php
@@ -373,9 +373,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
             $conceptKeywords = [];
         }
 
-        if (array_reduce($conceptKeywords, static function ($carry, $el): bool {
-            return $carry || !\is_string($el);
-        }, false)) {
+        if (array_reduce($conceptKeywords, static fn ($carry, $el): bool => $carry || !\is_string($el), false)) {
             throw new \InvalidArgumentException('setConceptKeywords must be passed an array of strings.');
         }
 
@@ -470,9 +468,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
             throw new \InvalidArgumentException('setEducationalAlignment must be passed a string or an array of strings.');
         }
 
-        if (array_reduce($educationalAlignment, static function ($carry, $el): bool {
-            return $carry || !\is_string($el);
-        }, false)) {
+        if (array_reduce($educationalAlignment, static fn ($carry, $el): bool => $carry || !\is_string($el), false)) {
             throw new \InvalidArgumentException('setEducationalAlignment must be passed a string or an array of strings.');
         }
 
@@ -548,9 +544,7 @@ class LsItem extends AbstractLsBase implements CaseApiInterface, LockableInterfa
     public function getChildIds(): array
     {
         $ids = $this->getChildren()->map(
-            static function (LsItem $item): int {
-                return $item->getId();
-            }
+            static fn (LsItem $item): int => $item->getId()
         );
 
         return $ids->toArray();

--- a/core/src/Entity/Framework/Mirror/Framework.php
+++ b/core/src/Entity/Framework/Mirror/Framework.php
@@ -3,16 +3,15 @@
 namespace App\Entity\Framework\Mirror;
 
 use App\Entity\Framework\LsDoc;
+use App\Repository\Framework\Mirror\FrameworkRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 use Swaggest\JsonDiff\JsonDiff;
 
-/**
- * @ORM\Table(name="mirror_framework")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\Mirror\FrameworkRepository")
- */
+#[ORM\Table(name: 'mirror_framework')]
+#[ORM\Entity(repositoryClass: FrameworkRepository::class)]
 class Framework
 {
     public const STATUS_NEW = 'new';
@@ -24,131 +23,82 @@ class Framework
     public const ERROR_GENERAL = 'general';
     public const ERROR_ID_CONFLICT = 'identifier_conflict';
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id;
 
-    /**
-     * @var Server
-     *
-     * @ORM\ManyToOne(targetEntity="Server", inversedBy="frameworks")
-     */
-    private $server;
+    #[ORM\ManyToOne(targetEntity: Server::class, inversedBy: 'frameworks')]
+    private Server $server;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="url", type="string", nullable=false)
-     */
-    private $url;
+    #[ORM\Column(name: 'url', type: 'string', nullable: false)]
+    private string $url;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="identifier", type="string", nullable=false)
-     */
-    private $identifier;
+    #[ORM\Column(name: 'identifier', type: 'string', nullable: false)]
+    private string $identifier;
 
-    /**
-     * @ORM\Column(name="creator", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'creator', type: 'string', nullable: true)]
     private ?string $creator = null;
 
-    /**
-     * @ORM\Column(name="title", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'title', type: 'string', nullable: true)]
     private ?string $title = null;
 
-    /**
-     * @var LsDoc|null
-     *
-     * @ORM\OneToOne(targetEntity="App\Entity\Framework\LsDoc", mappedBy="mirroredFramework")
-     */
-    private $framework;
+    #[ORM\OneToOne(mappedBy: 'mirroredFramework', targetEntity: LsDoc::class)]
+    private ?LsDoc $framework = null;
 
-    /**
-     * @ORM\Column(name="include", type="boolean", nullable=false)
-     */
+    #[ORM\Column(name: 'include', type: 'boolean', nullable: false)]
     private bool $include = true;
 
-    /**
-     * @ORM\Column(name="priority", type="integer", options={"default": 0})
-     */
+    #[ORM\Column(name: 'priority', type: 'integer', options: ['default' => 0])]
     private int $priority = 0;
 
-    /**
-     * @ORM\Column(name="status", type="string", options={"default": "new"})
-     */
+    #[ORM\Column(name: 'status', type: 'string', options: ['default' => 'new'])]
     private string $status = self::STATUS_NEW;
 
-    /**
-     * @ORM\Column(name="status_count", type="integer", nullable=false, options={"default": 0})
-     */
+    #[ORM\Column(name: 'status_count', type: 'integer', nullable: false, options: ['default' => 0])]
     private int $statusCount = 0;
 
-    /**
-     * @ORM\Column(name="last_check", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'last_check', type: 'datetime', nullable: true)]
     private ?\DateTimeInterface $lastCheck = null;
 
-    /**
-     * @ORM\Column(name="last_success", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'last_success', type: 'datetime', nullable: true)]
     private ?\DateTimeInterface $lastSuccess = null;
 
-    /**
-     * @ORM\Column(name="last_failure", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'last_failure', type: 'datetime', nullable: true)]
     private ?\DateTimeInterface $lastFailure = null;
 
-    /**
-     * @ORM\Column(name="last_change", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'last_change', type: 'datetime', nullable: true)]
     private ?\DateTimeInterface $lastChange = null;
 
-    /**
-     * @ORM\Column(name="next_check", type="datetime", nullable=true)
-     */
+    #[ORM\Column(name: 'next_check', type: 'datetime', nullable: true)]
     private ?\DateTimeInterface $nextCheck = null;
 
-    /**
-     * @ORM\Column(name="error_type", type="string", nullable=true)
-     */
+    #[ORM\Column(name: 'error_type', type: 'string', nullable: true)]
     private ?string $errorType = null;
 
     /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(name="updated_at", type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
-    private $updatedAt;
+    #[ORM\Column(name: 'updated_at', type: 'datetime', precision: 6)]
+    private \DateTimeInterface $updatedAt;
 
     /**
      * @var string|resource|null
-     *
-     * @ORM\Column(name="last_content", type="blob", nullable=true)
      */
+    #[ORM\Column(name: 'last_content', type: 'blob', nullable: true)]
     private $lastContent;
 
     /**
      * @var string|resource|null
-     *
-     * @ORM\Column(name="last_success_content", type="blob", nullable=true)
      */
+    #[ORM\Column(name: 'last_success_content', type: 'blob', nullable: true)]
     private $lastSuccessContent;
 
     /**
-     * @var Log[]|Collection
-     *
-     * @ORM\OneToMany(targetEntity="App\Entity\Framework\Mirror\Log", mappedBy="mirror", orphanRemoval=true, cascade={"persist"})
+     * @var Collection<array-key, Log>
      */
-    private $logs;
+    #[ORM\OneToMany(mappedBy: 'mirror', targetEntity: Log::class, cascade: ['persist'], orphanRemoval: true)]
+    private Collection $logs;
 
     public function __construct(Server $server, string $identifier)
     {
@@ -172,7 +122,7 @@ class Framework
         return $this->url;
     }
 
-    public function setUrl(string $url): self
+    public function setUrl(string $url): static
     {
         $this->url = $url;
 
@@ -189,7 +139,7 @@ class Framework
         return $this->include;
     }
 
-    public function setInclude(bool $include): self
+    public function setInclude(bool $include): static
     {
         $this->include = $include;
 
@@ -206,7 +156,7 @@ class Framework
         return $this->framework;
     }
 
-    public function setFramework(?LsDoc $framework): self
+    public function setFramework(?LsDoc $framework): static
     {
         $this->framework = $framework;
 
@@ -235,10 +185,10 @@ class Framework
 
     public function isIdConflicted(): bool
     {
-        return self::STATUS_ERROR === $this->status && self::ERROR_ID_CONFLICT === $this->errorType;
+        return static::STATUS_ERROR === $this->status && static::ERROR_ID_CONFLICT === $this->errorType;
     }
 
-    public function setErrorType(?string $errorType): self
+    public function setErrorType(?string $errorType): static
     {
         $this->errorType = $errorType;
 
@@ -255,7 +205,7 @@ class Framework
         return $this->title ?? 'Unknown';
     }
 
-    public function setTitle(string $title): self
+    public function setTitle(string $title): static
     {
         $this->title = $title;
 
@@ -267,7 +217,7 @@ class Framework
         return $this->creator ?? 'Unknown';
     }
 
-    public function setCreator(string $creator): self
+    public function setCreator(string $creator): static
     {
         $this->creator = $creator;
 
@@ -295,7 +245,7 @@ class Framework
         return $uncompressed;
     }
 
-    public function setLastSuccessContent(?string $lastSuccessContent): self
+    public function setLastSuccessContent(?string $lastSuccessContent): static
     {
         if (null === $lastSuccessContent) {
             $this->lastSuccessContent = null;
@@ -331,7 +281,7 @@ class Framework
         return $uncompressed;
     }
 
-    public function setLastContent(?string $lastContent): self
+    public function setLastContent(?string $lastContent): static
     {
         if (null === $lastContent) {
             $this->lastContent = null;
@@ -345,7 +295,7 @@ class Framework
     }
 
     /**
-     * @return Log[]|Collection
+     * @return Collection<array-key, Log>
      */
     public function getLogs(): Collection
     {
@@ -360,26 +310,26 @@ class Framework
         return $log;
     }
 
-    public function clearLogs(): self
+    public function clearLogs(): static
     {
         $this->logs->clear();
 
         return $this;
     }
 
-    public function markToRefresh(): self
+    public function markToRefresh(): static
     {
         $this->nextCheck = new \DateTimeImmutable();
         $this->priority = 1000;
-        $this->status = self::STATUS_SCHEDULED;
+        $this->status = static::STATUS_SCHEDULED;
 
         return $this;
     }
 
-    public function markSuccess(bool $changed = false): self
+    public function markSuccess(bool $changed = false): static
     {
         $this->errorType = null;
-        $this->status = self::STATUS_OK;
+        $this->status = static::STATUS_OK;
         ++$this->statusCount;
         if ($changed || null === $this->lastSuccess || (null !== $this->lastFailure && $this->lastFailure > $this->lastSuccess)) {
             $this->statusCount = 1;
@@ -396,10 +346,10 @@ class Framework
         return $this;
     }
 
-    public function markFailure(?string $errorType = self::ERROR_GENERAL): self
+    public function markFailure(?string $errorType = self::ERROR_GENERAL): static
     {
         $this->errorType = $errorType;
-        $this->status = self::STATUS_ERROR;
+        $this->status = static::STATUS_ERROR;
         ++$this->statusCount;
         if (null === $this->lastFailure || (null !== $this->lastSuccess && $this->lastFailure < $this->lastSuccess)) {
             $this->statusCount = 1;
@@ -417,7 +367,7 @@ class Framework
         return $this->status;
     }
 
-    public function setStatus($status): self
+    public function setStatus(string $status): static
     {
         $this->status = $status;
 

--- a/core/src/Entity/Framework/Mirror/Framework.php
+++ b/core/src/Entity/Framework/Mirror/Framework.php
@@ -26,7 +26,7 @@ class Framework
     #[ORM\Column(name: 'id', type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    private ?int $id;
+    private ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: Server::class, inversedBy: 'frameworks')]
     private Server $server;

--- a/core/src/Entity/Framework/Mirror/Framework.php
+++ b/core/src/Entity/Framework/Mirror/Framework.php
@@ -14,14 +14,14 @@ use Swaggest\JsonDiff\JsonDiff;
 #[ORM\Entity(repositoryClass: FrameworkRepository::class)]
 class Framework
 {
-    public const STATUS_NEW = 'new';
-    public const STATUS_SCHEDULED = 'scheduled';
-    public const STATUS_PROCESSING = 'processing';
-    public const STATUS_OK = 'ok';
-    public const STATUS_ERROR = 'error';
+    final public const STATUS_NEW = 'new';
+    final public const STATUS_SCHEDULED = 'scheduled';
+    final public const STATUS_PROCESSING = 'processing';
+    final public const STATUS_OK = 'ok';
+    final public const STATUS_ERROR = 'error';
 
-    public const ERROR_GENERAL = 'general';
-    public const ERROR_ID_CONFLICT = 'identifier_conflict';
+    final public const ERROR_GENERAL = 'general';
+    final public const ERROR_ID_CONFLICT = 'identifier_conflict';
 
     #[ORM\Column(name: 'id', type: 'integer')]
     #[ORM\Id]

--- a/core/src/Entity/Framework/Mirror/Framework.php
+++ b/core/src/Entity/Framework/Mirror/Framework.php
@@ -382,7 +382,7 @@ class Framework
                 json5_decode($framework),
                 JsonDiff::STOP_ON_DIFF + JsonDiff::REARRANGE_ARRAYS
             );
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/core/src/Entity/Framework/Mirror/Log.php
+++ b/core/src/Entity/Framework/Mirror/Log.php
@@ -2,54 +2,33 @@
 
 namespace App\Entity\Framework\Mirror;
 
+use App\Repository\Framework\Mirror\LogRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Table(name="mirror_log")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\Mirror\LogRepository")
- */
+#[ORM\Table(name: 'mirror_log')]
+#[ORM\Entity(repositoryClass: LogRepository::class)]
 class Log
 {
     public const STATUS_SUCCESS = 'success';
     public const STATUS_FAILURE = 'failure';
 
-    /**
-     * @var int
-     *
-     * @ORM\Id()
-     * @ORM\GeneratedValue()
-     * @ORM\Column(type="integer")
-     */
-    private $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
 
-    /**
-     * @var Framework
-     *
-     * @ORM\ManyToOne(targetEntity="App\Entity\Framework\Mirror\Framework", inversedBy="logs")
-     * @ORM\JoinColumn(nullable=false)
-     */
-    private $mirror;
+    #[ORM\ManyToOne(targetEntity: Framework::class, inversedBy: 'logs')]
+    #[ORM\JoinColumn(nullable: false)]
+    private Framework $mirror;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="status", type="string")
-     */
-    private $status;
+    #[ORM\Column(name: 'status', type: 'string')]
+    private string $status;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(type="text")
-     */
-    private $message;
+    #[ORM\Column(type: 'text')]
+    private string $message;
 
-    /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(type="datetime", precision=6)
-     */
-    private $occurredAt;
+    #[ORM\Column(type: 'datetime', precision: 6)]
+    private \DateTimeInterface $occurredAt;
 
     public function __construct(Framework $mirror, string $status, string $message)
     {
@@ -74,7 +53,7 @@ class Log
         return $this->message;
     }
 
-    public function getOccurredAt(): ?\DateTimeInterface
+    public function getOccurredAt(): \DateTimeInterface
     {
         return $this->occurredAt;
     }

--- a/core/src/Entity/Framework/Mirror/Log.php
+++ b/core/src/Entity/Framework/Mirror/Log.php
@@ -9,8 +9,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Entity(repositoryClass: LogRepository::class)]
 class Log
 {
-    public const STATUS_SUCCESS = 'success';
-    public const STATUS_FAILURE = 'failure';
+    final public const STATUS_SUCCESS = 'success';
+    final public const STATUS_FAILURE = 'failure';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/core/src/Entity/Framework/Mirror/OAuthCredential.php
+++ b/core/src/Entity/Framework/Mirror/OAuthCredential.php
@@ -2,59 +2,40 @@
 
 namespace App\Entity\Framework\Mirror;
 
+use App\Repository\Framework\Mirror\OAuthCredentialRepository;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
-/**
- * @ORM\Table(name="mirror_oauth")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\Mirror\OAuthCredentialRepository")
- */
+#[ORM\Table(name: 'mirror_oauth')]
+#[ORM\Entity(repositoryClass: OAuthCredentialRepository::class)]
 class OAuthCredential
 {
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'endpoint', type: 'string', nullable: false)]
+    private string $authenticationEndpoint;
+
+    #[ORM\Column(name: 'auth_key', type: 'string', nullable: false)]
+    private string $key;
+
+    #[ORM\Column(name: 'auth_secret', type: 'string', nullable: false)]
+    private string $secret;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="endpoint", type="string", nullable=false)
+     * @var array<array-key, string>
      */
-    private $authenticationEndpoint;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="auth_key", type="string", nullable=false)
-     */
-    private $key;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="auth_secret", type="string", nullable=false)
-     */
-    private $secret;
-
-    /**
-     * @var array|string[]
-     */
-    private $scopes = [
+    private array $scopes = [
         'http://purl.imsglobal.org/casenetwork/case/v1p0/scope/core.readonly',
     ];
 
     /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(name="updated_at", type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
-    private $updatedAt;
+    #[ORM\Column(name: 'updated_at', type: 'datetime', precision: 6)]
+    private \DateTimeInterface $updatedAt;
 
     public function getId(): int
     {
@@ -103,7 +84,7 @@ class OAuthCredential
     }
 
     /**
-     * @return array|string[]
+     * @return array<array-key, string>
      */
     public function getScopes(): array
     {

--- a/core/src/Entity/Framework/Mirror/Server.php
+++ b/core/src/Entity/Framework/Mirror/Server.php
@@ -12,11 +12,11 @@ use Gedmo\Mapping\Annotation as Gedmo;
 #[ORM\Entity(repositoryClass: ServerRepository::class)]
 class Server
 {
-    public const TYPE_CASE_1_0 = 'CASE/1.0';
-    public const TYPE_DIRECT = 'Direct URI/0.0';
+    final public const TYPE_CASE_1_0 = 'CASE/1.0';
+    final public const TYPE_DIRECT = 'Direct URI/0.0';
 
-    public const URL_CASE_1_0_LIST = '/ims/case/v1p0/CFDocuments';
-    public const URL_CASE_1_0_PACKAGE = '/ims/case/v1p0/CFPackages';
+    final public const URL_CASE_1_0_LIST = '/ims/case/v1p0/CFDocuments';
+    final public const URL_CASE_1_0_PACKAGE = '/ims/case/v1p0/CFPackages';
 
     #[ORM\Column(name: 'id', type: 'integer')]
     #[ORM\Id]

--- a/core/src/Entity/Framework/Mirror/Server.php
+++ b/core/src/Entity/Framework/Mirror/Server.php
@@ -2,15 +2,14 @@
 
 namespace App\Entity\Framework\Mirror;
 
+use App\Repository\Framework\Mirror\ServerRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
 
-/**
- * @ORM\Table(name="mirror_server")
- * @ORM\Entity(repositoryClass="App\Repository\Framework\Mirror\ServerRepository")
- */
+#[ORM\Table(name: 'mirror_server')]
+#[ORM\Entity(repositoryClass: ServerRepository::class)]
 class Server
 {
     public const TYPE_CASE_1_0 = 'CASE/1.0';
@@ -19,83 +18,46 @@ class Server
     public const URL_CASE_1_0_LIST = '/ims/case/v1p0/CFDocuments';
     public const URL_CASE_1_0_PACKAGE = '/ims/case/v1p0/CFPackages';
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    private $id;
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    #[ORM\Column(name: 'url', type: 'string', nullable: false)]
+    private string $url;
+
+    #[ORM\Column(name: 'api_type', type: 'string', nullable: false)]
+    private string $serverType = self::TYPE_CASE_1_0;
+
+    #[ORM\Column(name: 'check_server', type: 'boolean', nullable: false)]
+    private bool $checkServer = true;
+
+    #[ORM\Column(name: 'add_found', type: 'boolean', nullable: false)]
+    private bool $addFoundFrameworks;
+
+    #[ORM\ManyToOne(targetEntity: OAuthCredential::class)]
+    private ?OAuthCredential $credentials;
+
+    #[ORM\Column(name: 'priority', type: 'integer', options: ['default' => 0])]
+    private int $priority = 0;
+
+    #[ORM\Column(name: 'next_check', type: 'datetime', nullable: true)]
+    private ?\DateTimeInterface $nextCheck = null;
+
+    #[ORM\Column(name: 'last_check', type: 'datetime', nullable: true)]
+    private ?\DateTimeInterface $lastCheck = null;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="url", type="string", nullable=false)
-     */
-    private $url;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="api_type", type="string", nullable=false)
-     */
-    private $serverType = self::TYPE_CASE_1_0;
-
-    /**
-     * @var bool
-     * @ORM\Column(name="check_server", type="boolean", nullable=false)
-     */
-    private $checkServer = true;
-
-    /**
-     * @var bool
-     *
-     * @ORM\Column(name="add_found", type="boolean", nullable=false)
-     */
-    private $addFoundFrameworks;
-
-    /**
-     * @var OAuthCredential|null
-     *
-     * @ORM\ManyToOne(targetEntity="OAuthCredential")
-     */
-    private $credentials;
-
-    /**
-     * @var int
-     * @ORM\Column(name="priority", type="integer", options={"default": 0})
-     */
-    private $priority = 0;
-
-    /**
-     * @var \DateTimeInterface|null
-     *
-     * @ORM\Column(name="next_check", type="datetime", nullable=true)
-     */
-    private $nextCheck;
-
-    /**
-     * @var \DateTimeInterface|null
-     *
-     * @ORM\Column(name="last_check", type="datetime", nullable=true)
-     */
-    private $lastCheck;
-
-    /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(name="updated_at", type="datetime", precision=6)
      * @Gedmo\Timestampable(on="update")
      */
-    private $updatedAt;
+    #[ORM\Column(name: 'updated_at', type: 'datetime', precision: 6)]
+    private \DateTimeInterface $updatedAt;
 
     /**
-     * @var array<Framework>|Collection
-     *
-     * @ORM\OneToMany(targetEntity="App\Entity\Framework\Mirror\Framework", mappedBy="server")
+     * @var Collection<array-key, Framework>
      */
-    private $frameworks;
+    #[ORM\OneToMany(mappedBy: 'server', targetEntity: Framework::class)]
+    private Collection $frameworks;
 
     public function __construct(string $hostname, bool $addFoundFrameworks, ?OAuthCredential $credentials = null)
     {
@@ -123,11 +85,9 @@ class Server
         return $this->url;
     }
 
-    public function setUrl(string $url): self
+    public function setUrl(string $url): void
     {
         $this->url = $url;
-
-        return $this;
     }
 
     public function getServerType(): string
@@ -135,11 +95,9 @@ class Server
         return $this->serverType;
     }
 
-    public function setServerType(string $serverType): self
+    public function setServerType(string $serverType): void
     {
         $this->serverType = $serverType;
-
-        return $this;
     }
 
     public function isAddFoundFrameworks(): bool
@@ -147,11 +105,9 @@ class Server
         return $this->addFoundFrameworks;
     }
 
-    public function setAddFoundFrameworks(bool $addFoundFrameworks): self
+    public function setAddFoundFrameworks(bool $addFoundFrameworks): void
     {
         $this->addFoundFrameworks = $addFoundFrameworks;
-
-        return $this;
     }
 
     public function getCredentials(): ?OAuthCredential
@@ -159,11 +115,9 @@ class Server
         return $this->credentials;
     }
 
-    public function setCredentials(?OAuthCredential $credentials): self
+    public function setCredentials(?OAuthCredential $credentials): void
     {
         $this->credentials = $credentials;
-
-        return $this;
     }
 
     public function getNextCheck(): ?\DateTimeInterface
@@ -171,11 +125,9 @@ class Server
         return $this->nextCheck;
     }
 
-    public function setNextCheck(?\DateTimeInterface $nextCheck): self
+    public function setNextCheck(?\DateTimeInterface $nextCheck): void
     {
         $this->nextCheck = $nextCheck;
-
-        return $this;
     }
 
     public function getUpdatedAt(): \DateTimeInterface
@@ -183,15 +135,13 @@ class Server
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(\DateTimeInterface $updatedAt): self
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
-
-        return $this;
     }
 
     /**
-     * @return Collection|Framework[]
+     * @return Collection<array-key, Framework>
      */
     public function getFrameworks(): Collection
     {
@@ -203,11 +153,9 @@ class Server
         return $this->checkServer;
     }
 
-    public function setCheckServer(bool $checkServer): self
+    public function setCheckServer(bool $checkServer): void
     {
         $this->checkServer = $checkServer;
-
-        return $this;
     }
 
     public function getPriority(): int
@@ -215,11 +163,9 @@ class Server
         return $this->priority;
     }
 
-    public function setPriority(int $priority): self
+    public function setPriority(int $priority): void
     {
         $this->priority = $priority;
-
-        return $this;
     }
 
     public function getLastCheck(): ?\DateTimeInterface
@@ -227,11 +173,9 @@ class Server
         return $this->lastCheck;
     }
 
-    public function setLastCheck(\DateTimeInterface $lastCheck): self
+    public function setLastCheck(\DateTimeInterface $lastCheck): void
     {
         $this->lastCheck = $lastCheck;
-
-        return $this;
     }
 
     public function scheduleNextCheck(?\DateTimeInterface $when = null, int $in = 604800, ?int $variance = null): void

--- a/core/src/Entity/Framework/ObjectLock.php
+++ b/core/src/Entity/Framework/ObjectLock.php
@@ -40,7 +40,7 @@ class ObjectLock
 
         $this->user = $user;
         $this->timeout = new \DateTime("now + {$minutes} minutes");
-        $this->objectType = \get_class($obj);
+        $this->objectType = $obj::class;
         $this->objectId = (string) $obj->getId();
         if ($obj instanceof LsDoc) {
             $this->doc = $obj;

--- a/core/src/Entity/Framework/ObjectLock.php
+++ b/core/src/Entity/Framework/ObjectLock.php
@@ -14,7 +14,7 @@ class ObjectLock
     #[ORM\Column(name: 'id', type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
-    protected ?int $id;
+    protected ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false)]
@@ -30,7 +30,7 @@ class ObjectLock
     protected string $objectId;
 
     #[ORM\ManyToOne(targetEntity: LsDoc::class)]
-    protected ?LsDoc $doc;
+    protected ?LsDoc $doc = null;
 
     public function __construct(LockableInterface $obj, User $user, int $minutes = 5)
     {

--- a/core/src/Entity/Framework/ObjectLock.php
+++ b/core/src/Entity/Framework/ObjectLock.php
@@ -4,53 +4,32 @@ namespace App\Entity\Framework;
 
 use App\Entity\LockableInterface;
 use App\Entity\User\User;
+use App\Repository\Framework\ObjectLockRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Table(
- *     name="salt_object_lock",
- *     uniqueConstraints={
- *         @ORM\UniqueConstraint(name="lock_obj_idx", columns={"obj_type", "obj_id"})
- *     },
- *     indexes={
- *         @ORM\Index(name="expiry_idx", columns={"expiry"})
- *     }
- * )
- * @ORM\Entity(repositoryClass="App\Repository\Framework\ObjectLockRepository")
- */
+#[ORM\Table(name: 'salt_object_lock', indexes: [new ORM\Index(columns: ['expiry'], name: 'expiry_idx')], uniqueConstraints: [new ORM\UniqueConstraint(name: 'lock_obj_idx', columns: ['obj_type', 'obj_id'])])]
+#[ORM\Entity(repositoryClass: ObjectLockRepository::class)]
 class ObjectLock
 {
-    /**
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
+    #[ORM\Column(name: 'id', type: 'integer')]
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
     protected ?int $id;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\User\User")
-     * @ORM\JoinColumn(name="user_id", referencedColumnName="id", nullable=false)
-     */
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false)]
     protected User $user;
 
-    /**
-     * @ORM\Column(name="expiry", type="datetime", precision=6, nullable=false)
-     */
+    #[ORM\Column(name: 'expiry', type: 'datetime', precision: 6, nullable: false)]
     protected \DateTime $timeout;
 
-    /**
-     * @ORM\Column(name="obj_type", type="string", nullable=false)
-     */
+    #[ORM\Column(name: 'obj_type', type: 'string', nullable: false)]
     protected string $objectType;
 
-    /**
-     * @ORM\Column(name="obj_id", type="string", nullable=false)
-     */
+    #[ORM\Column(name: 'obj_id', type: 'string', nullable: false)]
     protected string $objectId;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="LsDoc")
-     */
+    #[ORM\ManyToOne(targetEntity: LsDoc::class)]
     protected ?LsDoc $doc;
 
     public function __construct(LockableInterface $obj, User $user, int $minutes = 5)

--- a/core/src/Entity/Framework/Package.php
+++ b/core/src/Entity/Framework/Package.php
@@ -9,42 +9,31 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class Package extends AbstractLsBase
 {
-    /**
-     * @Assert\Type(LsDoc::class)
-     */
+    #[Assert\Type(LsDoc::class)]
     private LsDoc $doc;
 
     /**
-     * @var Collection|LsItem[]
-     * @Assert\All({
-     *     @Assert\Type(LsItem::class)
-     * })
-     * @Assert\Valid(traverse=true)
+     * @var Collection<array-key, LsItem>
      */
+    #[Assert\All([new Assert\Type(LsItem::class)])]
+    #[Assert\Valid]
     private Collection $items;
 
     /**
-     * @var Collection|LsAssociation[]
-     * @Assert\All({
-     *     @Assert\Type(LsAssociation::class)
-     * })
-     * @Assert\Valid(traverse=true)
+     * @var Collection<array-key, LsAssociation>
      */
+    #[Assert\All([new Assert\Type(LsAssociation::class)])]
+    #[Assert\Valid]
     private Collection $associations;
 
     /**
-     * @var Collection|CfRubric[]
-     * @Assert\All({
-     *     @Assert\Type(CfRubric::class)
-     * })
-     * @Assert\Valid(traverse=true)
+     * @var Collection<array-key, CfRubric>
      */
+    #[Assert\All([new Assert\Type(CfRubric::class)])]
+    #[Assert\Valid]
     private Collection $rubrics;
 
-    /**
-     * @param string|UuidInterface|null $identifier
-     */
-    public function __construct(LsDoc $doc, $identifier = null)
+    public function __construct(LsDoc $doc, UuidInterface|string|null $identifier = null)
     {
         parent::__construct($identifier);
         $this->doc = $doc;

--- a/core/src/Entity/Session.php
+++ b/core/src/Entity/Session.php
@@ -2,42 +2,25 @@
 
 namespace App\Entity;
 
+use App\Repository\SessionRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Table(name="auth_session")
- * @ORM\Entity(repositoryClass="App\Repository\SessionRepository")
- */
+#[ORM\Table(name: 'auth_session')]
+#[ORM\Entity(repositoryClass: SessionRepository::class)]
 class Session
 {
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="id", type="binary", length=128)
-     * @ORM\Id()
-     */
-    private $id;
+    #[ORM\Column(name: 'id', type: 'binary', length: 128)]
+    #[ORM\Id]
+    private string $id;
 
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="sess_data", type="blob")
-     */
-    private $data;
+    #[ORM\Column(name: 'sess_data', type: 'blob')]
+    private string $data;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="sess_time", type="integer")
-     */
-    private $lastUsed;
+    #[ORM\Column(name: 'sess_time', type: 'integer')]
+    private int $lastUsed;
 
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="sess_lifetime", type="integer")
-     */
-    private $lifetime;
+    #[ORM\Column(name: 'sess_lifetime', type: 'integer')]
+    private int $lifetime;
 
     public function getId(): string
     {

--- a/core/src/Entity/Session.php
+++ b/core/src/Entity/Session.php
@@ -11,10 +11,10 @@ class Session
 {
     #[ORM\Column(name: 'id', type: 'binary', length: 128)]
     #[ORM\Id]
-    private string $id;
+    private mixed $id;
 
     #[ORM\Column(name: 'sess_data', type: 'blob')]
-    private string $data;
+    private mixed $data;
 
     #[ORM\Column(name: 'sess_time', type: 'integer')]
     private int $lastUsed;

--- a/core/src/Entity/User/Organization.php
+++ b/core/src/Entity/User/Organization.php
@@ -86,7 +86,7 @@ class Organization
     }
 
     /**
-     * @return \Doctrine\Common\Collections\Collection|\App\Entity\User\User[]
+     * @return Collection|User[]
      */
     public function getUsers()
     {
@@ -95,8 +95,6 @@ class Organization
 
     /**
      * Add a user to the organization
-     *
-     * @param \App\Entity\User\User $user
      */
     public function addUser(User $user): Organization
     {
@@ -107,8 +105,6 @@ class Organization
 
     /**
      * Remove a user from the organization
-     *
-     * @param \App\Entity\User\User $user
      */
     public function removeUser(User $user): Organization
     {
@@ -120,7 +116,7 @@ class Organization
     /**
      * Get the list of frameworks owned by the organization
      *
-     * @return \App\Entity\Framework\LsDoc[]|\Doctrine\Common\Collections\Collection
+     * @return LsDoc[]|Collection
      */
     public function getFrameworks()
     {

--- a/core/src/Entity/User/Organization.php
+++ b/core/src/Entity/User/Organization.php
@@ -3,67 +3,46 @@
 namespace App\Entity\User;
 
 use App\Entity\Framework\LsDoc;
+use App\Repository\User\OrganizationRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * Class Organization
- *
- * @ORM\Entity(repositoryClass="App\Repository\User\OrganizationRepository")
- * @ORM\Table(name="salt_org")
- * @UniqueEntity("name", message="The organization name is already being used")
- */
+#[ORM\Entity(repositoryClass: OrganizationRepository::class)]
+#[ORM\Table(name: 'salt_org')]
+#[UniqueEntity('name', message: 'The organization name is already being used')]
 class Organization
 {
-    /**
-     * @var int
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(name="id", type="integer")
-     */
-    protected $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(name: 'id', type: 'integer')]
+    protected ?int $id;
+
+    #[ORM\Column(name: 'name', type: 'string', length: 255, unique: true)]
+    #[Assert\NotBlank(groups: ['registration', 'Default'])]
+    protected string $name;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="name", type="string", length=255, unique=true)
-     *
-     * @Assert\NotBlank(groups={"registration", "Default"})
+     * @var Collection<array-key, User>
      */
-    protected $name;
+    #[ORM\OneToMany(mappedBy: 'org', targetEntity: User::class, fetch: 'EXTRA_LAZY', indexBy: 'id')]
+    private Collection $users;
 
     /**
-     * @var Collection|User[]
-     *
-     * @ORM\OneToMany(targetEntity="App\Entity\User\User", mappedBy="org", indexBy="id", fetch="EXTRA_LAZY")
+     * @var Collection<array-key, LsDoc>
      */
-    private $users;
+    #[ORM\OneToMany(mappedBy: 'org', targetEntity: LsDoc::class, fetch: 'EXTRA_LAZY', indexBy: 'id')]
+    protected Collection $frameworks;
 
-    /**
-     * @var LsDoc[]|Collection
-     * @ORM\OneToMany(targetEntity="App\Entity\Framework\LsDoc", mappedBy="org", indexBy="id", fetch="EXTRA_LAZY")
-     */
-    protected $frameworks;
-
-    /**
-     * Organization constructor.
-     */
     public function __construct()
     {
         $this->users = new ArrayCollection();
         $this->frameworks = new ArrayCollection();
     }
 
-    /**
-     * Returns the internal id of the user
-     *
-     * @return int
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -75,27 +54,19 @@ class Organization
         return $this;
     }
 
-    /**
-     * Get the name of the organization
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
     /**
-     * @return Collection|User[]
+     * @return Collection<array-key, User>
      */
-    public function getUsers()
+    public function getUsers(): Collection
     {
         return $this->users;
     }
 
-    /**
-     * Add a user to the organization
-     */
     public function addUser(User $user): Organization
     {
         $this->users->add($user);
@@ -116,9 +87,9 @@ class Organization
     /**
      * Get the list of frameworks owned by the organization
      *
-     * @return LsDoc[]|Collection
+     * @return Collection<array-key, LsDoc>
      */
-    public function getFrameworks()
+    public function getFrameworks(): Collection
     {
         return $this->frameworks;
     }

--- a/core/src/Entity/User/Organization.php
+++ b/core/src/Entity/User/Organization.php
@@ -18,7 +18,7 @@ class Organization
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(name: 'id', type: 'integer')]
-    protected ?int $id;
+    protected ?int $id = null;
 
     #[ORM\Column(name: 'name', type: 'string', length: 255, unique: true)]
     #[Assert\NotBlank(groups: ['registration', 'Default'])]

--- a/core/src/Entity/User/User.php
+++ b/core/src/Entity/User/User.php
@@ -3,6 +3,7 @@
 namespace App\Entity\User;
 
 use App\Entity\Framework\LsDoc;
+use App\Repository\User\UserRepository;
 use App\Validator\Constraints as CustomAssert;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -13,13 +14,9 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * Class User
- *
- * @ORM\Entity(repositoryClass="App\Repository\User\UserRepository")
- * @ORM\Table(name="salt_user")
- * @UniqueEntity("username", message="That email address is already being used", groups={"registration"})
- */
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+#[ORM\Table(name: 'salt_user')]
+#[UniqueEntity('username', message: 'That email address is already being used', groups: ['registration'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface
 {
     public const USER_ROLES = [
@@ -33,89 +30,56 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     public const SUSPENDED = 1;
     public const PENDING = 2;
 
-    /**
-     * @var int
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(name="id", type="integer")
-     */
-    protected $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(name: 'id', type: 'integer')]
+    protected ?int $id;
+
+    #[ORM\ManyToOne(targetEntity: Organization::class, inversedBy: 'users')]
+    #[ORM\JoinColumn(name: 'org_id', referencedColumnName: 'id', nullable: false)]
+    #[Assert\NotBlank]
+    protected Organization $org;
+
+    #[ORM\Column(name: 'username', type: 'string', length: 255, unique: true)]
+    #[Assert\NotBlank(groups: ['registration', 'Default'])]
+    #[Assert\Email(groups: ['registration'])]
+    protected string $username;
 
     /**
-     * @var Organization
-     *
-     * @ORM\ManyToOne(targetEntity="App\Entity\User\Organization", inversedBy="users")
-     * @ORM\JoinColumn(name="org_id", referencedColumnName="id", nullable=false)
-     *
-     * @Assert\NotBlank()
-     */
-    protected $org;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="username", type="string", length=255, unique=true)
-     *
-     * @Assert\NotBlank(groups={"registration", "Default"})
-     * @Assert\Email(groups={"registration"})
-     */
-    protected $username;
-
-    /**
-     * @var string
-     *
-     * @Assert\NotBlank(groups={"registration"})
-     * @Assert\Length(
-     *      min=8,
-     *      max=4096,
-     *      minMessage="Password must be at least {{ limit }} characters long",
-     *      maxMessage="Password cannot be longer than {{ limit }} characters",
-     *      groups={"registration"}
-     *  )
      * @CustomAssert\PasswordField(groups={"registration"})
      */
-    private $plainPassword;
+    #[Assert\NotBlank(groups: ['registration'])]
+    #[Assert\Length(min: 8, max: 4096, minMessage: 'Password must be at least {{ limit }} characters long', maxMessage: 'Password cannot be longer than {{ limit }} characters', groups: ['registration'])]
+    private string $plainPassword;
+
+    #[ORM\Column(name: 'password', type: 'string', nullable: true)]
+    protected ?string $password = null;
 
     /**
-     * @var string
-     *
-     * @ORM\Column(name="password", type="string", nullable=true)
+     * @var string[]|null
      */
-    protected $password;
+    #[ORM\Column(name: 'roles', type: 'json', nullable: true)]
+    protected ?array $roles = [];
+
+    #[ORM\Column(name: 'status', type: 'integer', nullable: false, options: ['default' => User::PENDING])]
+    protected int $status = self::ACTIVE;
+
+    #[ORM\Column(name: 'github_token', type: 'string', length: 40, nullable: true)]
+    protected ?string $githubToken = null;
 
     /**
-     * @var string[]
-     *
-     * @ORM\Column(name="roles", type="json", nullable=true)
+     * @var Collection<array-key, LsDoc>
      */
-    protected $roles = [];
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: LsDoc::class, fetch: 'EXTRA_LAZY', indexBy: 'id')]
+    protected Collection $frameworks;
 
     /**
-     * @var int
-     *
-     * @ORM\Column(name="status", type="integer", nullable=false, options={"default": User::PENDING})
+     * @var Collection<array-key, UserDocAcl>
      */
-    protected $status = self::ACTIVE;
+    #[ORM\OneToMany(mappedBy: 'user', targetEntity: UserDocAcl::class, fetch: 'EXTRA_LAZY', indexBy: 'lsDoc')]
+    protected Collection $docAcls;
 
-    /**
-     * @ORM\Column(name="github_token", type="string", length=40, nullable=true)
-     */
-    protected $githubToken;
-
-    /**
-     * @var LsDoc[]|Collection
-     * @ORM\OneToMany(targetEntity="App\Entity\Framework\LsDoc", mappedBy="user", indexBy="id", fetch="EXTRA_LAZY")
-     */
-    protected $frameworks;
-
-    /**
-     * @var UserDocAcl[]|Collection
-     * @ORM\OneToMany(targetEntity="UserDocAcl", mappedBy="user", indexBy="lsDoc", fetch="EXTRA_LAZY")
-     */
-    protected $docAcls;
-
-    public function __construct($username = null)
+    public function __construct(?string $username = null)
     {
         if (!empty($username)) {
             $this->username = $username;
@@ -124,17 +88,15 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
         $this->frameworks = new ArrayCollection();
     }
 
-    public static function getUserRoles()
+    public static function getUserRoles(): array
     {
         return static::USER_ROLES;
     }
 
     /**
-     * Returns the internal id of the user
-     *
-     * @return int
+     * Returns the internal id of the user.
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -143,10 +105,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      * Returns the username used to authenticate the user.
      *
      * @deprecated As of Symfony 5.3 getUserIdentifier() should be used instead
-     *
-     * @return string The username
      */
-    public function getUsername()
+    public function getUsername(): string
     {
         return $this->username;
     }
@@ -156,28 +116,19 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
         return $this->username;
     }
 
-    /**
-     * @param string $username
-     *
-     * @return $this
-     */
-    public function setUsername($username)
+    public function setUsername(string $username): void
     {
         $this->username = $username;
-
-        return $this;
     }
 
-    public function getPlainPassword()
+    public function getPlainPassword(): ?string
     {
         return $this->plainPassword;
     }
 
-    public function setPlainPassword($password)
+    public function setPlainPassword(?string $password): void
     {
         $this->plainPassword = $password;
-
-        return $this;
     }
 
     /**
@@ -191,11 +142,9 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
         return $this->password;
     }
 
-    public function setPassword($password)
+    public function setPassword(?string $password): void
     {
         $this->password = $password;
-
-        return $this;
     }
 
     /**
@@ -203,7 +152,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      *
      * @return string[] The user roles
      */
-    public function getRoles()
+    public function getRoles(): array
     {
         $roles = $this->roles;
 
@@ -215,30 +164,24 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     }
 
     /**
-     * @param string[] $roles The user roles
+     * @param iterable<array-key, string> $roles The user roles
      */
-    public function setRoles($roles)
+    public function setRoles(iterable $roles): void
     {
-        if (!$roles instanceof \Traversable) {
-            throw new \InvalidArgumentException('The passed roles are not an array');
-        }
-
         $this->roles = [];
         foreach ($roles as $role) {
             $this->addRole($role);
         }
     }
 
-    public function getGithubToken()
+    public function getGithubToken(): ?string
     {
         return $this->githubToken;
     }
 
-    public function setGithubToken($token)
+    public function setGithubToken(?string $token): void
     {
         $this->githubToken = $token;
-
-        return $this;
     }
 
     /**
@@ -259,7 +202,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      * This is important if, at any given point, sensitive information like
      * the plain-text password is stored on this object.
      */
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
     }
 
@@ -285,10 +228,8 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      *
      * Also implementation should consider that $user instance may implement
      * the extended user interface `AdvancedUserInterface`.
-     *
-     * @return bool
      */
-    public function isEqualTo(UserInterface $user)
+    public function isEqualTo(UserInterface $user): bool
     {
         if (!($user instanceof self)) {
             return false;
@@ -306,16 +247,12 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     }
 
     /**
-     * Add a role to a user
-     *
-     * @param string $role
-     *
-     * @return $this
+     * Add a role to a user.
      */
-    public function addRole($role)
+    public function addRole(string $role): void
     {
         if ('ROLE_USER' === $role) {
-            return $this;
+            return;
         }
 
         if (!in_array($role, static::USER_ROLES, true)) {
@@ -325,53 +262,39 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
         if (!in_array($role, $this->roles, true)) {
             $this->roles[] = $role;
         }
-
-        return $this;
     }
 
-    public function removeRole($role)
+    public function removeRole(string $role): void
     {
         if (($key = array_search($role, $this->roles, true)) !== false) {
             unset($this->roles[$key]);
         }
-
-        return $this;
     }
 
-    /**
-     * @return Organization
-     */
-    public function getOrg()
+    public function getOrg(): Organization
     {
         return $this->org;
     }
 
-    /**
-     * @param Organization $org
-     *
-     * @return User
-     */
-    public function setOrg($org)
+    public function setOrg(Organization $org): void
     {
         $this->org = $org;
-
-        return $this;
     }
 
     /**
-     * Get the frameworks owned by the user
+     * Get the frameworks owned by the user.
      *
-     * @return LsDoc[]|Collection
+     * @return Collection<array-key, LsDoc>
      */
-    public function getFrameworks()
+    public function getFrameworks(): Collection
     {
         return $this->frameworks;
     }
 
     /**
-     * @return Collection|UserDocAcl[]
+     * @return Collection<array-key, UserDocAcl>
      */
-    public function getDocAcls()
+    public function getDocAcls(): Collection
     {
         return $this->docAcls;
     }
@@ -386,7 +309,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      *
      * @see AccountExpiredException
      */
-    public function isAccountNonExpired()
+    public function isAccountNonExpired(): bool
     {
         // Accounts do not currently expire
         return true;
@@ -402,7 +325,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      *
      * @see LockedException
      */
-    public function isAccountNonLocked()
+    public function isAccountNonLocked(): bool
     {
         return !($this->isSuspended() || $this->isPending());
     }
@@ -417,7 +340,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      *
      * @see CredentialsExpiredException
      */
-    public function isCredentialsNonExpired()
+    public function isCredentialsNonExpired(): bool
     {
         // Currently credentials do not expire
         return true;
@@ -433,7 +356,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      *
      * @see DisabledException
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         return true;
     }
@@ -441,64 +364,35 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     /**
      * @return bool true if the user is suspended
      */
-    public function isSuspended()
+    public function isSuspended(): bool
     {
-        if ($this->status === static::SUSPENDED) {
-            return true;
-        }
-
-        return false;
+        return $this->status === static::SUSPENDED;
     }
 
-    /**
-     * Suspend the user
-     *
-     * @return $this
-     */
-    public function suspendUser()
+    public function suspendUser(): void
     {
         $this->status = static::SUSPENDED;
-
-        return $this;
     }
 
-    /**
-     * Activate the user
-     *
-     * @return $this
-     */
-    public function activateUser()
+    public function activateUser(): void
     {
         $this->status = static::ACTIVE;
-
-        return $this;
     }
 
     /**
-     * @return bool true if the user is pending for approval for approval
+     * @return bool true if the user is pending for approval
      */
-    public function isPending()
+    public function isPending(): bool
     {
-        if (static::PENDING === $this->status) {
-            return true;
-        }
-
-        return false;
+        return static::PENDING === $this->status;
     }
 
-    /**
-     * @param int $status
-     *
-     * @return $this
-     */
-    public function setStatus($status)
+    public function setStatus(int $status): void
     {
         $this->status = $status;
-
-        return $this;
     }
 
-    public function getStatus()
+    public function getStatus(): string
     {
         $statusArray = ['Active', 'Suspended', 'Pending'];
 

--- a/core/src/Entity/User/User.php
+++ b/core/src/Entity/User/User.php
@@ -19,16 +19,16 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[UniqueEntity('username', message: 'That email address is already being used', groups: ['registration'])]
 class User implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface
 {
-    public const USER_ROLES = [
+    final public const USER_ROLES = [
         'ROLE_EDITOR',
         'ROLE_ADMIN',
         'ROLE_SUPER_EDITOR',
         'ROLE_SUPER_USER',
     ];
 
-    public const ACTIVE = 0;
-    public const SUSPENDED = 1;
-    public const PENDING = 2;
+    final public const ACTIVE = 0;
+    final public const SUSPENDED = 1;
+    final public const PENDING = 2;
 
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]

--- a/core/src/Entity/User/User.php
+++ b/core/src/Entity/User/User.php
@@ -50,7 +50,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
      */
     #[Assert\NotBlank(groups: ['registration'])]
     #[Assert\Length(min: 8, max: 4096, minMessage: 'Password must be at least {{ limit }} characters long', maxMessage: 'Password cannot be longer than {{ limit }} characters', groups: ['registration'])]
-    private string $plainPassword;
+    private ?string $plainPassword = null;
 
     #[ORM\Column(name: 'password', type: 'string', nullable: true)]
     protected ?string $password = null;

--- a/core/src/Entity/User/User.php
+++ b/core/src/Entity/User/User.php
@@ -33,7 +33,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(name: 'id', type: 'integer')]
-    protected ?int $id;
+    protected ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: Organization::class, inversedBy: 'users')]
     #[ORM\JoinColumn(name: 'org_id', referencedColumnName: 'id', nullable: false)]

--- a/core/src/Entity/User/User.php
+++ b/core/src/Entity/User/User.php
@@ -339,7 +339,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     }
 
     /**
-     * @return \App\Entity\User\Organization
+     * @return Organization
      */
     public function getOrg()
     {
@@ -347,7 +347,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     }
 
     /**
-     * @param \App\Entity\User\Organization $org
+     * @param Organization $org
      *
      * @return User
      */
@@ -361,7 +361,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
     /**
      * Get the frameworks owned by the user
      *
-     * @return \App\Entity\Framework\LsDoc[]|\Doctrine\Common\Collections\Collection
+     * @return LsDoc[]|Collection
      */
     public function getFrameworks()
     {

--- a/core/src/Entity/User/UserDocAcl.php
+++ b/core/src/Entity/User/UserDocAcl.php
@@ -10,8 +10,8 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Table(name: 'salt_user_doc_acl', uniqueConstraints: [new ORM\UniqueConstraint(name: 'uniq_acl_id', columns: ['doc_id', 'user_id'])])]
 class UserDocAcl
 {
-    public const DENY = 0;
-    public const ALLOW = 1;
+    final public const DENY = 0;
+    final public const ALLOW = 1;
 
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]

--- a/core/src/Entity/User/UserDocAcl.php
+++ b/core/src/Entity/User/UserDocAcl.php
@@ -3,55 +3,31 @@
 namespace App\Entity\User;
 
 use App\Entity\Framework\LsDoc;
+use App\Repository\User\UserDocAclRepository;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * Class UserDocAcl
- *
- * @ORM\Entity(repositoryClass="App\Repository\User\UserDocAclRepository")
- * @ORM\Table(
- *     name="salt_user_doc_acl",
- *     uniqueConstraints={
- *         @ORM\UniqueConstraint(name="uniq_acl_id", columns={"doc_id", "user_id"})
- *     }
- * )
- */
+#[ORM\Entity(repositoryClass: UserDocAclRepository::class)]
+#[ORM\Table(name: 'salt_user_doc_acl', uniqueConstraints: [new ORM\UniqueConstraint(name: 'uniq_acl_id', columns: ['doc_id', 'user_id'])])]
 class UserDocAcl
 {
     public const DENY = 0;
     public const ALLOW = 1;
 
-    /**
-     * @var int
-     *
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="AUTO")
-     * @ORM\Column(name="id", type="integer")
-     */
-    protected $id;
+    #[ORM\Id]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    #[ORM\Column(name: 'id', type: 'integer')]
+    protected ?int $id;
 
-    /**
-     * @var User
-     *
-     * @ORM\ManyToOne(targetEntity="User", inversedBy="docAcls", fetch="EAGER")
-     * @ORM\JoinColumn(name="user_id", referencedColumnName="id", nullable=false)
-     */
-    protected $user;
+    #[ORM\ManyToOne(targetEntity: User::class, fetch: 'EAGER', inversedBy: 'docAcls')]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false)]
+    protected User $user;
 
-    /**
-     * @var LsDoc
-     *
-     * @ORM\ManyToOne(targetEntity="App\Entity\Framework\LsDoc", inversedBy="docAcls", fetch="EAGER")
-     * @ORM\JoinColumn(name="doc_id", referencedColumnName="id", nullable=false)
-     */
-    protected $lsDoc;
+    #[ORM\ManyToOne(targetEntity: LsDoc::class, fetch: 'EAGER', inversedBy: 'docAcls')]
+    #[ORM\JoinColumn(name: 'doc_id', referencedColumnName: 'id', nullable: false)]
+    protected LsDoc $lsDoc;
 
-    /**
-     * @var int 0|1 indicating Deny or Allow
-     *
-     * @ORM\Column(name="access", type="smallint", nullable=false)
-     */
-    protected $access;
+    #[ORM\Column(name: 'access', type: 'smallint', nullable: false)]
+    protected int $access;
 
     /**
      * UserDocAcl constructor.
@@ -74,7 +50,7 @@ class UserDocAcl
     }
 
     /**
-     * The User that the ACL is for
+     * The User that the ACL is for.
      */
     public function getUser(): User
     {
@@ -82,7 +58,7 @@ class UserDocAcl
     }
 
     /**
-     * The Document that the ACL is for
+     * The Document that the ACL is for.
      */
     public function getLsDoc(): LsDoc
     {
@@ -90,7 +66,7 @@ class UserDocAcl
     }
 
     /**
-     * Determine if the user has access
+     * Determine if the user has access.
      *
      * @return int 0|1 indicating Deny or Allow
      */

--- a/core/src/Entity/User/UserDocAcl.php
+++ b/core/src/Entity/User/UserDocAcl.php
@@ -16,7 +16,7 @@ class UserDocAcl
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'AUTO')]
     #[ORM\Column(name: 'id', type: 'integer')]
-    protected ?int $id;
+    protected ?int $id = null;
 
     #[ORM\ManyToOne(targetEntity: User::class, fetch: 'EAGER', inversedBy: 'docAcls')]
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false)]

--- a/core/src/EventListener/ApiExceptionListener.php
+++ b/core/src/EventListener/ApiExceptionListener.php
@@ -68,9 +68,9 @@ class ApiExceptionListener implements EventSubscriberInterface
 
         $response = new Response(
             $this->serializer->serialize($err, $_format),
-            404
+            Response::HTTP_NOT_FOUND
         );
-        $response->setStatusCode(404, $errText); // Add error text for IMS Global Compliance Test Suite
+        $response->setStatusCode(Response::HTTP_NOT_FOUND, $errText); // Add error text for IMS Global Compliance Test Suite
 
         $response->setMaxAge(60);
         $response->setSharedMaxAge(60);

--- a/core/src/EventListener/CommandEventRouter.php
+++ b/core/src/EventListener/CommandEventRouter.php
@@ -69,10 +69,10 @@ class CommandEventRouter implements EventSubscriberInterface
     {
         $command = $event->getCommand();
 
-        $this->info('Routing command', ['command' => \get_class($command)]);
+        $this->info('Routing command', ['command' => $command::class]);
 
         try {
-            $dispatcher->dispatch($event, \get_class($command));
+            $dispatcher->dispatch($event, $command::class);
 
             if ($validationErrors = $command->getValidationErrors()) {
                 $errors = [];
@@ -81,10 +81,10 @@ class CommandEventRouter implements EventSubscriberInterface
                     $errors[] = $error->getMessage();
                 }
                 $errorString = implode(' ', $errors);
-                $this->info('Error in command', ['command' => \get_class($command), 'errors' => $errorString]);
+                $this->info('Error in command', ['command' => $command::class, 'errors' => $errorString]);
             }
         } catch (\Exception $e) {
-            $this->info('Exception in command', ['command' => \get_class($command), 'exception' => $e]);
+            $this->info('Exception in command', ['command' => $command::class, 'exception' => $e]);
 
             throw $e;
         }
@@ -97,7 +97,7 @@ class CommandEventRouter implements EventSubscriberInterface
             if (null !== $notification) {
                 $changeEntry = new ChangeEntry($notification->getDoc(), $this->getCurrentUser(), $notification->getMessage(), $notification->getChanged());
             } else {
-                $changeEntry = new ChangeEntry(null, $this->getCurrentUser(), \get_class($command), []);
+                $changeEntry = new ChangeEntry(null, $this->getCurrentUser(), $command::class, []);
             }
         }
 
@@ -160,7 +160,7 @@ class CommandEventRouter implements EventSubscriberInterface
     {
         $notification = $command->getNotificationEvent();
         if (null === $notification) {
-            $notification = new NotificationEvent('X01', 'Command '.\get_class($command).' handled', null, [], false);
+            $notification = new NotificationEvent('X01', 'Command '.$command::class.' handled', null, [], false);
         }
 
         if (null === $notification->getUsername()) {

--- a/core/src/Form/DTO/AddAclUserDTO.php
+++ b/core/src/Form/DTO/AddAclUserDTO.php
@@ -10,26 +10,23 @@ class AddAclUserDTO
 {
     /**
      * @var User
-     *
-     * @Assert\Type(User::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(User::class)]
+    #[Assert\NotNull]
     public $user;
 
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     public $lsDoc;
 
     /**
      * @var int
-     *
-     * @Assert\Type("int")
-     * @Assert\NotNull()
      */
+    #[Assert\Type('int')]
+    #[Assert\NotNull]
     public $access;
 
     public function __construct(LsDoc $doc, int $access, User $user = null)

--- a/core/src/Form/DTO/AddAclUsernameDTO.php
+++ b/core/src/Form/DTO/AddAclUsernameDTO.php
@@ -14,18 +14,16 @@ class AddAclUsernameDTO
 
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     public $lsDoc;
 
     /**
      * @var int
-     *
-     * @Assert\Type("int")
-     * @Assert\NotNull()
      */
+    #[Assert\Type('int')]
+    #[Assert\NotNull]
     public $access;
 
     public function __construct(LsDoc $doc, int $access, ?string $username = null)

--- a/core/src/Form/DTO/ChangeLsItemParentDTO.php
+++ b/core/src/Form/DTO/ChangeLsItemParentDTO.php
@@ -9,16 +9,14 @@ class ChangeLsItemParentDTO
 {
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
      */
+    #[Assert\Type(LsItem::class)]
     public $parentItem;
 
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     public $lsItem;
 }

--- a/core/src/Form/DTO/ChangePasswordDTO.php
+++ b/core/src/Form/DTO/ChangePasswordDTO.php
@@ -16,11 +16,7 @@ class ChangePasswordDTO
 
     /**
      * @var string
-     *
-     * @Assert\Length(
-     *     min = 6,
-     *     minMessage="The new password should be at least 6 characters long"
-     * )
      */
+    #[Assert\Length(min: 6, minMessage: 'The new password should be at least 6 characters long')]
     public $newPassword;
 }

--- a/core/src/Form/DTO/CopyToLsDocDTO.php
+++ b/core/src/Form/DTO/CopyToLsDocDTO.php
@@ -10,17 +10,15 @@ class CopyToLsDocDTO
 {
     /**
      * @var LsDoc
-     *
-     * @Assert\Type(LsDoc::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsDoc::class)]
+    #[Assert\NotNull]
     public $lsDoc;
 
     /**
      * @var LsItem
-     *
-     * @Assert\Type(LsItem::class)
-     * @Assert\NotNull()
      */
+    #[Assert\Type(LsItem::class)]
+    #[Assert\NotNull]
     public $lsItem;
 }

--- a/core/src/Form/DTO/MirroredFrameworkDTO.php
+++ b/core/src/Form/DTO/MirroredFrameworkDTO.php
@@ -9,11 +9,10 @@ class MirroredFrameworkDTO
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     * @Assert\Url()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    #[Assert\Url]
     public $url;
 
     /**

--- a/core/src/Form/DTO/MirroredServerDTO.php
+++ b/core/src/Form/DTO/MirroredServerDTO.php
@@ -9,18 +9,16 @@ class MirroredServerDTO
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
-     * @Assert\Url()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
+    #[Assert\Url]
     public $url;
 
     /**
      * @var bool
-     *
-     * @Assert\NotNull()
      */
+    #[Assert\NotNull]
     public $autoAddFoundFrameworks = false;
 
     /**

--- a/core/src/Form/DTO/OAuthCredentialDTO.php
+++ b/core/src/Form/DTO/OAuthCredentialDTO.php
@@ -8,25 +8,22 @@ class OAuthCredentialDTO
 {
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     public $authenticationEndpoint;
 
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     public $key;
 
     /**
      * @var string
-     *
-     * @Assert\NotNull()
-     * @Assert\NotBlank()
      */
+    #[Assert\NotNull]
+    #[Assert\NotBlank]
     public $secret;
 }

--- a/core/src/Form/DataTransformer/EducationAlignmentTransformer.php
+++ b/core/src/Form/DataTransformer/EducationAlignmentTransformer.php
@@ -39,9 +39,7 @@ class EducationAlignmentTransformer implements DataTransformerInterface
             return null;
         }
 
-        $grades = array_map(static function (LsDefGrade $alignment) {
-            return $alignment->getCode();
-        }, $alignmentArray);
+        $grades = array_map(static fn (LsDefGrade $alignment) => $alignment->getCode(), $alignmentArray);
 
         return implode(',', $grades);
     }

--- a/core/src/Form/DataTransformer/ItemTypeTransformer.php
+++ b/core/src/Form/DataTransformer/ItemTypeTransformer.php
@@ -88,7 +88,7 @@ class ItemTypeTransformer implements DataTransformerInterface
                 ->setParameter('id', $value)
                 ->getQuery()
                 ->getSingleResult();
-        } catch (\Exception $ex) {
+        } catch (\Exception) {
             // this will happen if the form submits invalid data
             throw new TransformationFailedException(sprintf('The choice "%s" does not exist or is not unique', $value));
         }

--- a/core/src/Form/Type/AbstractLsDocCreateType.php
+++ b/core/src/Form/Type/AbstractLsDocCreateType.php
@@ -140,9 +140,7 @@ abstract class AbstractLsDocCreateType extends AbstractType
             ->resetViewTransformers()
             ->resetModelTransformers()
             ->addModelTransformer(new CallbackTransformer(
-                static function (?FrameworkType $frameworkType): ?string {
-                    return $frameworkType ? $frameworkType->getFrameworkType() : '';
-                },
+                static fn (?FrameworkType $frameworkType): ?string => $frameworkType ? $frameworkType->getFrameworkType() : '',
                 static function (?string $frameworkType) use ($em): ?FrameworkType {
                     if (null === $frameworkType) {
                         return null;

--- a/core/src/Form/Type/AddAclUserType.php
+++ b/core/src/Form/Type/AddAclUserType.php
@@ -6,7 +6,7 @@ use App\Entity\Framework\LsDoc;
 use App\Entity\User\User;
 use App\Form\DTO\AddAclUserDTO;
 use Doctrine\ORM\EntityRepository;
-use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\Expr\Join;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -34,7 +34,7 @@ class AddAclUserType extends AbstractType
                     }
 
                     return $er->createQueryBuilder('u')
-                        ->leftJoin('u.docAcls', 'acl', Expr\Join::WITH, 'acl.lsDoc = :docId')
+                        ->leftJoin('u.docAcls', 'acl', Join::WITH, 'acl.lsDoc = :docId')
                         ->where('u.org = :orgId')
                         ->andWhere('acl.user is null')
                         ->addOrderBy('u.username')

--- a/core/src/Form/Type/LsAssociationType.php
+++ b/core/src/Form/Type/LsAssociationType.php
@@ -50,10 +50,8 @@ class LsAssociationType extends AbstractType
                 'required' => false,
                 'multiple' => false,
                 'class' => LsDoc::class,
-                'query_builder' => static function (EntityRepository $er) {
-                    return $er->createQueryBuilder('d')
-                        ->orderBy('d.title', 'ASC');
-                },
+                'query_builder' => static fn (EntityRepository $er) => $er->createQueryBuilder('d')
+                    ->orderBy('d.title', 'ASC'),
             ])
         ;
 
@@ -66,11 +64,9 @@ class LsAssociationType extends AbstractType
                     'required' => true,
                     'multiple' => false,
                     'class' => LsItem::class,
-                    'query_builder' => static function (EntityRepository $er) use ($lsDoc) {
-                        return $er->createQueryBuilder('d')
-                            ->where('d.lsDoc = '.$lsDoc->getId())
-                            ->orderBy('d.fullStatement', 'ASC');
-                    },
+                    'query_builder' => static fn (EntityRepository $er) => $er->createQueryBuilder('d')
+                        ->where('d.lsDoc = '.$lsDoc->getId())
+                        ->orderBy('d.fullStatement', 'ASC'),
                 ]);
             } else {
                 $form->add('destinationNodeIdentifier', null, [

--- a/core/src/Form/Type/LsDefAssociationGroupingType.php
+++ b/core/src/Form/Type/LsDefAssociationGroupingType.php
@@ -23,10 +23,8 @@ class LsDefAssociationGroupingType extends AbstractType
                     'group_by' => 'creator',
                     'required' => true,
                     'multiple' => false,
-                    'query_builder' => function (EntityRepository $er) {
-                        return $er->createQueryBuilder('i')
-                            ->orderBy('i.title', 'ASC');
-                    },
+                    'query_builder' => fn (EntityRepository $er) => $er->createQueryBuilder('i')
+                        ->orderBy('i.title', 'ASC'),
                 ])
         ;
     }

--- a/core/src/Form/Type/LsItemParentType.php
+++ b/core/src/Form/Type/LsItemParentType.php
@@ -32,15 +32,12 @@ class LsItemParentType extends AbstractType
                 'required' => false,
                 'multiple' => false,
                 'class' => LsItem::class,
-                'query_builder' => function (EntityRepository $er) use ($lsDoc, $id) {
-                    return $er->createQueryBuilder('i')
-                        ->where('i.lsDoc = :docId')
-                        ->andWhere('i.id != :id')
-                        ->orderBy('i.fullStatement', 'ASC')
-                        ->setParameter('docId', $lsDoc->getId())
-                        ->setParameter('id', $id)
-                    ;
-                },
+                'query_builder' => fn (EntityRepository $er) => $er->createQueryBuilder('i')
+                    ->where('i.lsDoc = :docId')
+                    ->andWhere('i.id != :id')
+                    ->orderBy('i.fullStatement', 'ASC')
+                    ->setParameter('docId', $lsDoc->getId())
+                    ->setParameter('id', $id),
             ])
         ;
     }

--- a/core/src/Form/Type/LsItemType.php
+++ b/core/src/Form/Type/LsItemType.php
@@ -9,7 +9,6 @@ use App\Entity\Framework\LsDefLicence;
 use App\Entity\Framework\LsItem;
 use App\Form\DataTransformer\EducationAlignmentTransformer;
 use App\Form\DataTransformer\ItemTypeTransformer;
-use App\Repository\Framework\LsDefGradeRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -38,7 +37,7 @@ class LsItemType extends AbstractType
         $builder
             ->add('fullStatement')
             ->add('humanCodingScheme')
-            //->add('identifier', null, ['attr'=>['placeholder'=>'hhhhhhhh-hhhh-hhhh-hhhh-hhhhhhhhhhhh']])
+            // ->add('identifier', null, ['attr'=>['placeholder'=>'hhhhhhhh-hhhh-hhhh-hhhh-hhhhhhhhhhhh']])
             ->add('listEnumInSource')
             ->add('abbreviatedStatement')
             ->add('conceptKeywords')
@@ -51,17 +50,10 @@ class LsItemType extends AbstractType
                 'class' => LsDefGrade::class,
                 'label' => 'Education Level',
                 'choice_label' => 'code',
-                'choice_attr' => static function (LsDefGrade $val, $key, $index) {
-                    return ['data-title' => $val->getTitle()];
-                },
+                'choice_attr' => static fn (LsDefGrade $val, $key, $index) => ['data-title' => $val->getTitle()],
                 'required' => false,
                 'multiple' => true,
-                'query_builder' => static function (EntityRepository $er) {
-                    /** @var LsDefGradeRepository $er */
-                    return $er->createQueryBuilder('g')
-                        ->addOrderBy('g.rank')
-                        ;
-                },
+                'query_builder' => static fn (EntityRepository $er) => $er->createQueryBuilder('g')->addOrderBy('g.rank'),
             ])
             ->add('itemType', Select2EntityType::class, [
                 'multiple' => false,

--- a/core/src/Form/Type/MirroredFrameworkDTOType.php
+++ b/core/src/Form/Type/MirroredFrameworkDTOType.php
@@ -27,17 +27,12 @@ class MirroredFrameworkDTOType extends AbstractType
                 'help' => 'Select the credentials to use when authenticating with the server if they are needed.',
                 'help_html' => true,
                 'class' => OAuthCredential::class,
-                'choice_label' => static function (OAuthCredential $credential) {
-                    return $credential->getKey().' @ '.$credential->getAuthenticationEndpoint();
-                },
+                'choice_label' => static fn (OAuthCredential $credential) => $credential->getKey().' @ '.$credential->getAuthenticationEndpoint(),
                 'required' => false,
                 'multiple' => false,
-                'query_builder' => static function (EntityRepository $repo) {
-                    return $repo->createQueryBuilder('c')
-                        ->orderBy('c.key', 'ASC')
-                        ->addOrderBy('c.authenticationEndpoint', 'ASC')
-                        ;
-                },
+                'query_builder' => static fn (EntityRepository $repo) => $repo->createQueryBuilder('c')
+                    ->orderBy('c.key', 'ASC')
+                    ->addOrderBy('c.authenticationEndpoint', 'ASC'),
             ])
         ;
     }

--- a/core/src/Form/Type/MirroredServerDTOType.php
+++ b/core/src/Form/Type/MirroredServerDTOType.php
@@ -40,17 +40,12 @@ class MirroredServerDTOType extends AbstractType
                 'help' => 'Select the credentials to use when authenticating with the server if they are needed.',
                 'help_html' => true,
                 'class' => OAuthCredential::class,
-                'choice_label' => static function (OAuthCredential $credential) {
-                    return $credential->getKey().' @ '.$credential->getAuthenticationEndpoint();
-                },
+                'choice_label' => static fn (OAuthCredential $credential) => $credential->getKey().' @ '.$credential->getAuthenticationEndpoint(),
                 'required' => false,
                 'multiple' => false,
-                'query_builder' => static function (EntityRepository $repo) {
-                    return $repo->createQueryBuilder('c')
-                        ->orderBy('c.key', 'ASC')
-                        ->addOrderBy('c.authenticationEndpoint', 'ASC')
-                        ;
-                },
+                'query_builder' => static fn (EntityRepository $repo) => $repo->createQueryBuilder('c')
+                    ->orderBy('c.key', 'ASC')
+                    ->addOrderBy('c.authenticationEndpoint', 'ASC'),
             ])
         ;
 

--- a/core/src/Handler/Email/AbstractEmailHandler.php
+++ b/core/src/Handler/Email/AbstractEmailHandler.php
@@ -73,7 +73,7 @@ abstract class AbstractEmailHandler extends BaseValidatedHandler
         try {
             $this->mailer->send($email);
         } catch (\Exception $e) {
-            $this->setEmailNotSentNotification($command, 'Error: '.get_class($e).': '.$e->getMessage());
+            $this->setEmailNotSentNotification($command, 'Error: '.$e::class.': '.$e->getMessage());
 
             throw $e;
         }

--- a/core/src/Repository/ChangeEntryRepository.php
+++ b/core/src/Repository/ChangeEntryRepository.php
@@ -79,7 +79,7 @@ class ChangeEntryRepository extends ServiceEntityRepository
             ->setParameter('doc_id', $doc->getId())
             ->orderBy('a.id', 'DESC')
             ->setFirstResult($offset)
-            ->setMaxResults(($limit > 0) ? $limit : 1000000)
+            ->setMaxResults(($limit > 0) ? $limit : 1_000_000)
             ->getQuery()
             ->setHydrationMode(Query::HYDRATE_ARRAY)
             ->toIterable();
@@ -114,7 +114,7 @@ class ChangeEntryRepository extends ServiceEntityRepository
             ->where('a.doc IS NULL')
             ->orderBy('a.id', 'DESC')
             ->setFirstResult($offset)
-            ->setMaxResults(($limit > 0) ? $limit : 1000000)
+            ->setMaxResults(($limit > 0) ? $limit : 1_000_000)
             ->getQuery()
             ->setHydrationMode(Query::HYDRATE_ARRAY)
             ->toIterable();

--- a/core/src/Repository/Framework/LsDocRepository.php
+++ b/core/src/Repository/Framework/LsDocRepository.php
@@ -7,6 +7,7 @@ use App\Entity\Framework\LsAssociation;
 use App\Entity\Framework\LsDoc;
 use App\Util\Compare;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Driver\Exception;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -241,7 +242,7 @@ class LsDocRepository extends ServiceEntityRepository
     /**
      * Delete an LsDoc and all associated items and associations.
      *
-     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws Exception
      * @throws \Doctrine\DBAL\Exception
      */
     public function deleteDocument(LsDoc $lsDoc, ?\Closure $progressCallback = null): void

--- a/core/src/Repository/Framework/ObjectLockRepository.php
+++ b/core/src/Repository/Framework/ObjectLockRepository.php
@@ -25,7 +25,7 @@ class ObjectLockRepository extends ServiceEntityRepository
 
     public function findLockFor(LockableInterface $obj): ?ObjectLock
     {
-        $lock = $this->findOneBy(['objectType' => \get_class($obj), 'objectId' => $obj->getId()]);
+        $lock = $this->findOneBy(['objectType' => $obj::class, 'objectId' => $obj->getId()]);
 
         return $lock;
     }

--- a/core/src/Security/LoginFormAuthenticator.php
+++ b/core/src/Security/LoginFormAuthenticator.php
@@ -54,9 +54,7 @@ class LoginFormAuthenticator extends AbstractLoginFormAuthenticator implements E
         }
 
         return new Passport(
-            new UserBadge($username, function ($userIdentifier) {
-                return $this->userRepository->loadUserByIdentifier($userIdentifier);
-            }),
+            new UserBadge($username, fn ($userIdentifier) => $this->userRepository->loadUserByIdentifier($userIdentifier)),
             new PasswordCredentials($password),
             [new CsrfTokenBadge('authenticate', $csrfToken)]
         );

--- a/core/src/Security/LoginFormAuthenticator.php
+++ b/core/src/Security/LoginFormAuthenticator.php
@@ -24,7 +24,7 @@ class LoginFormAuthenticator extends AbstractLoginFormAuthenticator implements E
 {
     use TargetPathTrait;
 
-    public const LOGIN_ROUTE = 'login';
+    final public const LOGIN_ROUTE = 'login';
 
     public function __construct(
         private UserRepository $userRepository,

--- a/core/src/Security/Voter/AssociationVoter.php
+++ b/core/src/Security/Voter/AssociationVoter.php
@@ -14,11 +14,11 @@ class AssociationVoter extends Voter
     use RoleCheckTrait;
     use DeferDecisionTrait;
 
-    public const ADD_TO = 'add-association-to';
-    public const CREATE = 'create';
-    public const EDIT = 'edit';
+    final public const ADD_TO = 'add-association-to';
+    final public const CREATE = 'create';
+    final public const EDIT = 'edit';
 
-    public const ASSOCIATION = 'lsassociation';
+    final public const ASSOCIATION = 'lsassociation';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/AssociationVoter.php
+++ b/core/src/Security/Voter/AssociationVoter.php
@@ -29,19 +29,16 @@ class AssociationVoter extends Voter
             return false;
         }
 
-        switch ($attribute) {
-            case self::ADD_TO:
-                // User can add to a specific doc or "some doc"
-                return $subject instanceof LsDoc || $subject instanceof LsItem || null === $subject;
-            case self::CREATE:
-                // User can create an association
-                return static::ASSOCIATION === $subject;
-            case self::EDIT:
-                // User can edit the LsAssociation
-                return $subject instanceof LsAssociation;
-            default:
-                return false;
-        }
+        return match ($attribute) {
+            // User can add to a specific doc or "some doc"
+            self::ADD_TO => $subject instanceof LsDoc || $subject instanceof LsItem || null === $subject,
+
+            // User can create an association
+            self::CREATE => static::ASSOCIATION === $subject,
+
+            // User can edit the LsAssociation
+            self::EDIT => $subject instanceof LsAssociation,
+        };
     }
 
     /**
@@ -55,16 +52,12 @@ class AssociationVoter extends Voter
             return false;
         }
 
-        switch ($attribute) {
-            case self::ADD_TO:
-                return $this->canAddTo($subject, $token);
-            case self::CREATE:
-                return (static::ASSOCIATION === $subject) && $this->canCreate($token);
-            case self::EDIT:
-                return $this->canEdit($subject, $token);
-            default:
-                return false;
-        }
+        return match ($attribute) {
+            self::ADD_TO => $this->canAddTo($subject, $token),
+            self::CREATE => (static::ASSOCIATION === $subject) && $this->canCreate($token),
+            self::EDIT => $this->canEdit($subject, $token),
+            default => false,
+        };
     }
 
     /**

--- a/core/src/Security/Voter/CommentVoter.php
+++ b/core/src/Security/Voter/CommentVoter.php
@@ -12,10 +12,10 @@ class CommentVoter extends Voter
     use RoleCheckTrait;
     use FeatureCheckTrait;
 
-    public const COMMENT = 'comment';
-    public const VIEW = 'comment_view';
-    public const UPDATE = 'comment_update';
-    public const DELETE = 'comment_delete';
+    final public const COMMENT = 'comment';
+    final public const VIEW = 'comment_view';
+    final public const UPDATE = 'comment_update';
+    final public const DELETE = 'comment_delete';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/DeferDecisionTrait.php
+++ b/core/src/Security/Voter/DeferDecisionTrait.php
@@ -4,14 +4,13 @@ namespace App\Security\Voter;
 
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 trait DeferDecisionTrait
 {
     private AccessDecisionManagerInterface $decisionManager;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setDecisionManager(AccessDecisionManagerInterface $decisionManager): void
     {
         $this->decisionManager = $decisionManager;

--- a/core/src/Security/Voter/FeatureCheckTrait.php
+++ b/core/src/Security/Voter/FeatureCheckTrait.php
@@ -4,15 +4,14 @@ namespace App\Security\Voter;
 
 use Qandidate\Toggle\ContextFactory;
 use Qandidate\Toggle\ToggleManager;
+use Symfony\Contracts\Service\Attribute\Required;
 
 trait FeatureCheckTrait
 {
     private ToggleManager $toggleManager;
     private ContextFactory $toggleContextFactory;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setToggleManager(ToggleManager $toggleManager, ContextFactory $contextFactory): void
     {
         $this->toggleManager = $toggleManager;

--- a/core/src/Security/Voter/FeatureVoter.php
+++ b/core/src/Security/Voter/FeatureVoter.php
@@ -9,9 +9,9 @@ class FeatureVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const FEATURE = 'feature';
+    final public const FEATURE = 'feature';
 
-    public const DEV_ENV = 'dev_env';
+    final public const DEV_ENV = 'dev_env';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/FrameworkAccessVoter.php
+++ b/core/src/Security/Voter/FrameworkAccessVoter.php
@@ -12,13 +12,13 @@ class FrameworkAccessVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const LIST = 'list'; // User can see the framework in a list
-    public const VIEW = 'view';
-    public const EDIT = 'edit';
-    public const DELETE = 'delete';
-    public const CREATE = 'create';
+    final public const LIST = 'list'; // User can see the framework in a list
+    final public const VIEW = 'view';
+    final public const EDIT = 'edit';
+    final public const DELETE = 'delete';
+    final public const CREATE = 'create';
 
-    public const FRAMEWORK = 'lsdoc';
+    final public const FRAMEWORK = 'lsdoc';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/FrameworkAccessVoter.php
+++ b/core/src/Security/Voter/FrameworkAccessVoter.php
@@ -47,24 +47,14 @@ class FrameworkAccessVoter extends Voter
      */
     protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
     {
-        switch ($attribute) {
-            case self::CREATE:
-                return (static::FRAMEWORK === $subject) && $this->canCreateFramework($token);
-
-            case self::LIST:
-                return $this->canListFramework($subject, $token);
-
-            case self::VIEW:
-                return $this->canViewFramework($subject, $token);
-
-            case self::EDIT:
-                return $this->canEditFramework($subject, $token);
-
-            case self::DELETE:
-                return $this->canDeleteFramework($subject, $token);
-        }
-
-        return false;
+        return match ($attribute) {
+            self::CREATE => (static::FRAMEWORK === $subject) && $this->canCreateFramework($token),
+            self::LIST => $this->canListFramework($subject, $token),
+            self::VIEW => $this->canViewFramework($subject, $token),
+            self::EDIT => $this->canEditFramework($subject, $token),
+            self::DELETE => $this->canDeleteFramework($subject, $token),
+            default => false,
+        };
     }
 
     private function canCreateFramework(TokenInterface $token): bool

--- a/core/src/Security/Voter/FrameworkManageEditorsVoter.php
+++ b/core/src/Security/Voter/FrameworkManageEditorsVoter.php
@@ -11,7 +11,7 @@ class FrameworkManageEditorsVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const MANAGE_EDITORS = 'manage_editors';
+    final public const MANAGE_EDITORS = 'manage_editors';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/ItemVoter.php
+++ b/core/src/Security/Voter/ItemVoter.php
@@ -54,15 +54,11 @@ class ItemVoter extends Voter
             return false;
         }
 
-        switch ($attribute) {
-            case self::ADD_TO:
-                return $this->canAddTo($subject, $token);
-
-            case self::EDIT:
-                return $this->canEdit($subject, $token);
-        }
-
-        return false;
+        return match ($attribute) {
+            self::ADD_TO => $this->canAddTo($subject, $token),
+            self::EDIT => $this->canEdit($subject, $token),
+            default => false,
+        };
     }
 
     /**

--- a/core/src/Security/Voter/ItemVoter.php
+++ b/core/src/Security/Voter/ItemVoter.php
@@ -13,8 +13,8 @@ class ItemVoter extends Voter
     use DeferDecisionTrait;
     use RoleCheckTrait;
 
-    public const ADD_TO = 'add-standard-to';
-    public const EDIT = 'edit';
+    final public const ADD_TO = 'add-standard-to';
+    final public const EDIT = 'edit';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/ManageAdditionalFieldVoter.php
+++ b/core/src/Security/Voter/ManageAdditionalFieldVoter.php
@@ -9,9 +9,9 @@ class ManageAdditionalFieldVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const MANAGE = 'manage';
+    final public const MANAGE = 'manage';
 
-    public const ADDITIONAL_FIELDS = 'additional_fields';
+    final public const ADDITIONAL_FIELDS = 'additional_fields';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/ManageLogVoter.php
+++ b/core/src/Security/Voter/ManageLogVoter.php
@@ -9,9 +9,9 @@ class ManageLogVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const MANAGE = 'manage';
+    final public const MANAGE = 'manage';
 
-    public const SYSTEM_LOGS = 'system_logs';
+    final public const SYSTEM_LOGS = 'system_logs';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/ManageMirrorVoter.php
+++ b/core/src/Security/Voter/ManageMirrorVoter.php
@@ -9,9 +9,9 @@ class ManageMirrorVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const MANAGE = 'manage';
+    final public const MANAGE = 'manage';
 
-    public const MIRRORS = 'mirrors';
+    final public const MIRRORS = 'mirrors';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/ManageOrganizationVoter.php
+++ b/core/src/Security/Voter/ManageOrganizationVoter.php
@@ -9,9 +9,9 @@ class ManageOrganizationVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const MANAGE = 'manage';
+    final public const MANAGE = 'manage';
 
-    public const ORGANIZATIONS = 'organizations';
+    final public const ORGANIZATIONS = 'organizations';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/ManageUserVoter.php
+++ b/core/src/Security/Voter/ManageUserVoter.php
@@ -10,10 +10,10 @@ class ManageUserVoter extends Voter
 {
     use RoleCheckTrait;
 
-    public const MANAGE = 'manage';
+    final public const MANAGE = 'manage';
 
-    public const USERS = 'users';
-    public const ALL_USERS = 'all_users';
+    final public const USERS = 'users';
+    final public const ALL_USERS = 'all_users';
 
     /**
      * {@inheritdoc}

--- a/core/src/Security/Voter/RoleCheckTrait.php
+++ b/core/src/Security/Voter/RoleCheckTrait.php
@@ -3,14 +3,13 @@
 namespace App\Security\Voter;
 
 use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 trait RoleCheckTrait
 {
     private RoleChecker $roleChecker;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setRoleChecker(RoleHierarchyInterface $roleHierarchy): void
     {
         $this->roleChecker = new RoleChecker($roleHierarchy);

--- a/core/src/Security/Voter/RoleChecker.php
+++ b/core/src/Security/Voter/RoleChecker.php
@@ -7,10 +7,10 @@ use Symfony\Component\Security\Core\Role\RoleHierarchyInterface;
 
 class RoleChecker
 {
-    public const ROLE_EDITOR = 'ROLE_EDITOR';
-    public const ROLE_ADMIN = 'ROLE_ADMIN';
-    public const ROLE_SUPER_EDITOR = 'ROLE_SUPER_EDITOR';
-    public const ROLE_SUPER_USER = 'ROLE_SUPER_USER';
+    final public const ROLE_EDITOR = 'ROLE_EDITOR';
+    final public const ROLE_ADMIN = 'ROLE_ADMIN';
+    final public const ROLE_SUPER_EDITOR = 'ROLE_SUPER_EDITOR';
+    final public const ROLE_SUPER_USER = 'ROLE_SUPER_USER';
 
     private RoleHierarchyInterface $roleHierarchy;
 

--- a/core/src/Serializer/CaseJson/CfPackageNormalizer.php
+++ b/core/src/Serializer/CaseJson/CfPackageNormalizer.php
@@ -87,9 +87,7 @@ final class CfPackageNormalizer implements NormalizerAwareInterface, ContextAwar
             }
         }
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 
     public function setNormalizer(NormalizerInterface $normalizer): void

--- a/core/src/Serializer/CaseJson/CfRubricCriterionLevelNormalizer.php
+++ b/core/src/Serializer/CaseJson/CfRubricCriterionLevelNormalizer.php
@@ -54,8 +54,6 @@ final class CfRubricCriterionLevelNormalizer implements ContextAwareNormalizerIn
             'position' => $object->getPosition(),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/CfRubricCriterionNormalizer.php
+++ b/core/src/Serializer/CaseJson/CfRubricCriterionNormalizer.php
@@ -65,8 +65,6 @@ final class CfRubricCriterionNormalizer implements NormalizerAwareInterface, Con
             $data['CFRubricCriterionLevels'][] = $this->normalizer->normalize($level, $format, $context);
         }
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/CfRubricNormalizer.php
+++ b/core/src/Serializer/CaseJson/CfRubricNormalizer.php
@@ -58,8 +58,6 @@ final class CfRubricNormalizer implements NormalizerAwareInterface, ContextAware
             $data['CFRubricCriteria'][] = $this->normalizer->normalize($criterion, $format, $context);
         }
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/LsAssociationNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsAssociationNormalizer.php
@@ -59,14 +59,10 @@ final class LsAssociationNormalizer implements ContextAwareNormalizerInterface
                 'annotation' => $object->getAnnotation(),
             ];
 
-            $data['_opensalt'] = array_filter($data['_opensalt'], static function ($val) {
-                return null !== $val;
-            });
+            $data['_opensalt'] = array_filter($data['_opensalt'], static fn ($val) => null !== $val);
         }
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 
     protected function createOutLink(LsAssociation $association, string $which, array $context): ?array

--- a/core/src/Serializer/CaseJson/LsDefAssociationGroupingNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsDefAssociationGroupingNormalizer.php
@@ -48,8 +48,6 @@ final class LsDefAssociationGroupingNormalizer implements ContextAwareNormalizer
             'description' => $object->getDescription(),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/LsDefConceptNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsDefConceptNormalizer.php
@@ -50,8 +50,6 @@ final class LsDefConceptNormalizer implements ContextAwareNormalizerInterface
             'keywords' => $object->getKeywords(),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/LsDefItemTypeNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsDefItemTypeNormalizer.php
@@ -50,8 +50,6 @@ final class LsDefItemTypeNormalizer implements ContextAwareNormalizerInterface
             'hierarchyCode' => $object->getHierarchyCode(),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/LsDefLicenceNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsDefLicenceNormalizer.php
@@ -49,8 +49,6 @@ final class LsDefLicenceNormalizer implements ContextAwareNormalizerInterface
             'licenseText' => $object->getLicenceText(),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/LsDefSubjectNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsDefSubjectNormalizer.php
@@ -49,8 +49,6 @@ final class LsDefSubjectNormalizer implements ContextAwareNormalizerInterface
             'hierarchyCode' => $object->getHierarchyCode(),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/LsDocNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsDocNormalizer.php
@@ -74,8 +74,6 @@ final class LsDocNormalizer implements ContextAwareNormalizerInterface
             'associationSet' => $this->createAssociationLinks($object, $context),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Serializer/CaseJson/LsItemNormalizer.php
+++ b/core/src/Serializer/CaseJson/LsItemNormalizer.php
@@ -74,8 +74,6 @@ final class LsItemNormalizer implements ContextAwareNormalizerInterface
             'associationSet' => $this->createAssociationLinks($object, $context),
         ];
 
-        return array_filter($data, static function ($val) {
-            return null !== $val;
-        });
+        return array_filter($data, static fn ($val) => null !== $val);
     }
 }

--- a/core/src/Service/Api1RouteMap.php
+++ b/core/src/Service/Api1RouteMap.php
@@ -47,7 +47,7 @@ final class Api1RouteMap
     private static function findByClassName(IdentifiableInterface $obj): ?string
     {
         // Performance hack -- try to do a quick lookup of the class name
-        $class = get_class($obj);
+        $class = $obj::class;
         $class = str_replace('Proxies\\__CG__\\', '', $class);
 
         return self::getForClass($class);

--- a/core/src/Service/AsnImport.php
+++ b/core/src/Service/AsnImport.php
@@ -201,7 +201,7 @@ class AsnImport
             try {
                 $asnDoc = $this->requestAsnDocument($urlPrefix.$asnId.'_full.json');
                 break;
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // If on the second ASN URL then the first will not be found
             }
         }

--- a/core/src/Service/BucketService.php
+++ b/core/src/Service/BucketService.php
@@ -22,7 +22,7 @@ class BucketService
     public function uploadFile(UploadedFile $file, string $dir): string
     {
         $filesystem = $this->filesystem;
-        $name = explode('.', $file->getClientOriginalName())[0].'-'.mt_rand();
+        $name = explode('.', $file->getClientOriginalName())[0].'-'.random_int(0, mt_getrandmax());
         $path = "/$dir/$name.".$file->getClientOriginalExtension();
         $url = '';
 

--- a/core/src/Service/BucketService.php
+++ b/core/src/Service/BucketService.php
@@ -2,7 +2,7 @@
 
 namespace App\Service;
 
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use League\Flysystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -26,7 +26,7 @@ class BucketService
         $path = "/$dir/$name.".$file->getClientOriginalExtension();
         $url = '';
 
-        $original = Psr7\Utils::tryFopen($file->getRealPath(), 'rb');
+        $original = Utils::tryFopen($file->getRealPath(), 'rb');
         $filesystem->writeStream($path, $original, ['directory_visibility' => 'public', 'visibility' => 'public']);
 
         if (!empty($this->attachmentUrlPrefix)) {

--- a/core/src/Service/CodeceptionBridge.php
+++ b/core/src/Service/CodeceptionBridge.php
@@ -6,6 +6,7 @@ use App\Service\User\UserManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Qandidate\Toggle\ContextFactory;
 use Qandidate\Toggle\ToggleManager;
+use Symfony\Contracts\Service\Attribute\Required;
 
 class CodeceptionBridge
 {
@@ -29,26 +30,20 @@ class CodeceptionBridge
      */
     private $userManager;
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setEntityManager(EntityManagerInterface $entityManager)
     {
         $this->entityManager = $entityManager;
     }
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setToggles(ToggleManager $toggleManager, ContextFactory $contextFactory)
     {
         $this->toggleManager = $toggleManager;
         $this->contextFactory = $contextFactory;
     }
 
-    /**
-     * @required
-     */
+    #[Required]
     public function setUserManager(UserManager $userManager)
     {
         $this->userManager = $userManager;

--- a/core/src/Service/ExcelExport.php
+++ b/core/src/Service/ExcelExport.php
@@ -21,9 +21,7 @@ final class ExcelExport
         if (null === self::$customItemFields) {
             $customFieldsArray = $this->getEntityManager()->getRepository(AdditionalField::class)
                 ->findBy(['appliesTo' => LsItem::class]);
-            self::$customItemFields = array_map(function (AdditionalField $cf) {
-                return $cf->getName();
-            }, $customFieldsArray);
+            self::$customItemFields = array_map(fn (AdditionalField $cf) => $cf->getName(), $customFieldsArray);
         }
     }
 

--- a/core/src/Service/ExcelExport.php
+++ b/core/src/Service/ExcelExport.php
@@ -218,9 +218,7 @@ final class ExcelExport
             'K' => '[itemType][title]',
             'L' => '[license]',
         ];
-
-        end($columns);
-        $lastCol = key($columns);
+        $lastCol = array_key_last($columns);
         foreach (self::$customItemFields as $customField) {
             $columns[++$lastCol] = sprintf('[extra][customFields][%s]', $customField);
         }

--- a/core/src/Service/ExcelExport.php
+++ b/core/src/Service/ExcelExport.php
@@ -72,7 +72,7 @@ final class ExcelExport
             $item = $itemsArray[$item['id']];
             $smartLevel[$item['id']] = $smartLevel[$parentId].'.'.$j;
 
-            if (count($item['children']) > 0) {
+            if ((is_countable($item['children']) ? count($item['children']) : 0) > 0) {
                 $this->getSmartLevel($item['children'], $item['id'], $itemsArray, $smartLevel);
             }
 
@@ -196,7 +196,7 @@ final class ExcelExport
             }
             ++$j;
 
-            if (count($item['children']) > 0) {
+            if ((is_countable($item['children']) ? count($item['children']) : 0) > 0) {
                 $this->addItemRows($item['children'], $activeSheet, $j, $items, $smartLevel);
             }
         }
@@ -270,7 +270,7 @@ final class ExcelExport
     {
         $column = 13;
 
-        if (count(self::$customItemFields) > 0) {
+        if (count((array) self::$customItemFields) > 0) {
             foreach (self::$customItemFields as $cf) {
                 $sheet->setCellValue([$column, 1], $cf);
                 ++$column;

--- a/core/src/Service/ExcelImport.php
+++ b/core/src/Service/ExcelImport.php
@@ -26,9 +26,7 @@ final class ExcelImport
         if (null === self::$itemCustomFields) {
             $customFieldsArray = $this->getEntityManager()->getRepository(AdditionalField::class)
                 ->findBy(['appliesTo' => LsItem::class]);
-            self::$itemCustomFields = array_map(static function (AdditionalField $cf) {
-                return $cf->getName();
-            }, $customFieldsArray);
+            self::$itemCustomFields = array_map(static fn (AdditionalField $cf) => $cf->getName(), $customFieldsArray);
         }
     }
 
@@ -382,9 +380,7 @@ final class ExcelImport
 
         $existingItems = $docRepo->findAllItems($doc);
 
-        $existingItems = array_filter($existingItems, static function ($item) use ($array) {
-            return !array_key_exists($item['identifier'], $array);
-        });
+        $existingItems = array_filter($existingItems, static fn ($item) => !array_key_exists($item['identifier'], $array));
 
         foreach ($existingItems as $existingItem) {
             $element = $repo->findOneByIdentifier($existingItem['identifier']);
@@ -402,9 +398,7 @@ final class ExcelImport
 
         $existingAssociations = $docRepo->findAllAssociations($doc);
 
-        $existingAssociations = array_filter($existingAssociations, static function ($association) use ($array) {
-            return !array_key_exists($association['identifier'], $array);
-        });
+        $existingAssociations = array_filter($existingAssociations, static fn ($association) => !array_key_exists($association['identifier'], $array));
 
         foreach ($existingAssociations as $existingAssociation) {
             $element = $repo->findOneByIdentifier($existingAssociation['identifier']);

--- a/core/src/Service/ExcelImport.php
+++ b/core/src/Service/ExcelImport.php
@@ -12,6 +12,8 @@ use App\Entity\Framework\LsDoc;
 use App\Entity\Framework\LsItem;
 use App\Util\EducationLevelSet;
 use Doctrine\ORM\EntityManagerInterface;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Ramsey\Uuid\Uuid;
 
@@ -39,7 +41,7 @@ final class ExcelImport
     {
         set_time_limit(180); // increase time limit for large files
 
-        $phpExcelObject = \PhpOffice\PhpSpreadsheet\IOFactory::load($excelFilePath);
+        $phpExcelObject = IOFactory::load($excelFilePath);
 
         /** @var LsItem[] $items */
         $items = [];
@@ -167,7 +169,7 @@ final class ExcelImport
         if (!empty($this->getCellValueOrNull($sheet, 12, 2))) {
             $doc->setStatusStart(
                 new \DateTime(
-                    \PhpOffice\PhpSpreadsheet\Style\NumberFormat::toFormattedString(
+                    NumberFormat::toFormattedString(
                         $this->getCellValueOrNull($sheet, 12, 2),
                         'YYYY-MM-DD'
                     )
@@ -180,7 +182,7 @@ final class ExcelImport
         if (!empty($this->getCellValueOrNull($sheet, 13, 2))) {
             $doc->setStatusEnd(
                 new \DateTime(
-                    \PhpOffice\PhpSpreadsheet\Style\NumberFormat::toFormattedString(
+                    NumberFormat::toFormattedString(
                         $this->getCellValueOrNull($sheet, 13, 2),
                         'YYYY-MM-DD'
                     )

--- a/core/src/Service/FrameworkService.php
+++ b/core/src/Service/FrameworkService.php
@@ -391,7 +391,7 @@ class FrameworkService
             // so in this case, it's OK to just delete any existing childof association and create a new one below
             $deleted = $assocRepo->removeAllAssociationsOfType($lsItem, LsAssociation::CHILD_OF);
 
-            if (0 < \count($deleted) && !array_key_exists('assoc-d', $rv['changes'])) {
+            if (0 < (is_countable($deleted) ? \count($deleted) : 0) && !array_key_exists('assoc-d', $rv['changes'])) {
                 $rv['changes']['assoc-d'] = [];
             }
             foreach ($deleted as $assoc) {

--- a/core/src/Service/FrameworkService.php
+++ b/core/src/Service/FrameworkService.php
@@ -391,7 +391,7 @@ class FrameworkService
             // so in this case, it's OK to just delete any existing childof association and create a new one below
             $deleted = $assocRepo->removeAllAssociationsOfType($lsItem, LsAssociation::CHILD_OF);
 
-            if (0 < (is_countable($deleted) ? \count($deleted) : 0) && !array_key_exists('assoc-d', $rv['changes'])) {
+            if (0 < \count($deleted) && !array_key_exists('assoc-d', $rv['changes'])) {
                 $rv['changes']['assoc-d'] = [];
             }
             foreach ($deleted as $assoc) {

--- a/core/src/Service/FrameworkUpdater.php
+++ b/core/src/Service/FrameworkUpdater.php
@@ -80,7 +80,7 @@ class FrameworkUpdater
                     if (is_string($destination)) {
                         if ($this->validatePresenceOnAssociation($destination, $associationSeparatedByComma)) {
                             $assocNotMatched[$associationSeparatedByComma]['matched'] = false;
-                        } elseif ('data:text/x-ref-unresolved;base64,' === substr($destination, 0, 34)) {
+                        } elseif (str_starts_with($destination, 'data:text/x-ref-unresolved;base64,')) {
                             if ($this->validatePresenceOnAssociation($association->getHumanCodingSchemeFromDestinationNodeUri(), $associationSeparatedByComma)) {
                                 $assocNotMatched[$associationSeparatedByComma]['matched'] = false;
                             }

--- a/core/src/Service/FrameworkUpdater.php
+++ b/core/src/Service/FrameworkUpdater.php
@@ -158,7 +158,7 @@ class FrameworkUpdater
                     ->findByAllIdentifierOrHumanCodingSchemeByLsDoc($frameworkToAssociate, $cfAssociation);
             }
 
-            if ((is_countable($itemsAssociated) ? count($itemsAssociated) : 0) > 0) {
+            if (count($itemsAssociated) > 0) {
                 foreach ($itemsAssociated as $itemAssociated) {
                     $this->saveAssociation($lsDoc, $lsItem, $itemAssociated, $assocType);
                 }

--- a/core/src/Service/FrameworkUpdater.php
+++ b/core/src/Service/FrameworkUpdater.php
@@ -158,7 +158,7 @@ class FrameworkUpdater
                     ->findByAllIdentifierOrHumanCodingSchemeByLsDoc($frameworkToAssociate, $cfAssociation);
             }
 
-            if (count($itemsAssociated) > 0) {
+            if ((is_countable($itemsAssociated) ? count($itemsAssociated) : 0) > 0) {
                 foreach ($itemsAssociated as $itemAssociated) {
                     $this->saveAssociation($lsDoc, $lsItem, $itemAssociated, $assocType);
                 }

--- a/core/src/Service/GithubImport.php
+++ b/core/src/Service/GithubImport.php
@@ -189,7 +189,7 @@ class GithubImport
                     ->findByAllIdentifierOrHumanCodingSchemeByLsDoc($frameworkToAssociate, $cfAssociation);
             }
 
-            if (count($itemsAssociated) > 0) {
+            if ((is_countable($itemsAssociated) ? count($itemsAssociated) : 0) > 0) {
                 foreach ($itemsAssociated as $itemAssociated) {
                     $this->saveAssociation($lsDoc, $lsItem, $itemAssociated, $assocType);
                 }

--- a/core/src/Service/GithubImport.php
+++ b/core/src/Service/GithubImport.php
@@ -189,7 +189,7 @@ class GithubImport
                     ->findByAllIdentifierOrHumanCodingSchemeByLsDoc($frameworkToAssociate, $cfAssociation);
             }
 
-            if ((is_countable($itemsAssociated) ? count($itemsAssociated) : 0) > 0) {
+            if (count($itemsAssociated) > 0) {
                 foreach ($itemsAssociated as $itemAssociated) {
                     $this->saveAssociation($lsDoc, $lsItem, $itemAssociated, $assocType);
                 }

--- a/core/src/Service/LoggerTrait.php
+++ b/core/src/Service/LoggerTrait.php
@@ -2,6 +2,7 @@
 
 namespace App\Service;
 
+use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -23,7 +24,7 @@ trait LoggerTrait
      *
      * @return void
      *
-     * @throws \Psr\Log\InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function log($level, $message, array $context = [])
     {

--- a/core/src/Service/MirrorServer.php
+++ b/core/src/Service/MirrorServer.php
@@ -232,13 +232,8 @@ class MirrorServer
             $this->warning('Error authenticating to server', ['message' => $e->getMessage(), 'exception' => $guzzleException->getMessage()]);
 
             throw new \RuntimeException('Error authenticating to server: '.$guzzleException->getMessage(), 0, $e);
-        } catch (RequestException $e) {
+        } catch (RequestException|\Exception $e) {
             $this->warning('Error requesting URL from server', ['exception' => $e->getMessage()]);
-
-            throw new \RuntimeException('Error requesting URL from server.', 0, $e);
-        } catch (\Exception $e) {
-            $this->warning('Error requesting URL from server', ['exception' => $e->getMessage()]);
-
             throw new \RuntimeException('Error requesting URL from server.', 0, $e);
         }
 

--- a/core/src/Service/SubtypeUpdater.php
+++ b/core/src/Service/SubtypeUpdater.php
@@ -148,7 +148,7 @@ class SubtypeUpdater
 //            $type = strtolower($type);
 //            $type = preg_replace('/^<-ispartof$/', 'haspart', $type);
 //            $type = preg_replace('/^ispartof->$/', 'ispartof', $type);
-            $types[$type] = $types[$type] ?? [];
+            $types[$type] ??= [];
             $types[$type][$subtype] = 1;
 
             $annotation = $this->getValueFromSheet($sheet, 13, $rowIndex);

--- a/core/src/Service/UriGenerator.php
+++ b/core/src/Service/UriGenerator.php
@@ -10,7 +10,7 @@ use Symfony\Component\Routing\RouterInterface;
 
 class UriGenerator
 {
-    public const PACKAGE_PREFIX = 'p';
+    final public const PACKAGE_PREFIX = 'p';
 
     public function __construct(private RouterInterface $router)
     {

--- a/core/src/Twig/Extension/CaseUriExtension.php
+++ b/core/src/Twig/Extension/CaseUriExtension.php
@@ -30,9 +30,7 @@ class CaseUriExtension extends AbstractExtension
     public function getTests(): array
     {
         return [
-            new TwigTest('numeric', function ($value) {
-                return is_numeric($value);
-            }),
+            new TwigTest('numeric', fn ($value) => is_numeric($value)),
         ];
     }
 }

--- a/core/src/Util/Compare.php
+++ b/core/src/Util/Compare.php
@@ -59,9 +59,9 @@ class Compare
 
         $xa = preg_split('/[\s.,-]/', $x);
         $ya = preg_split('/[\s.,-]/', $y);
-        $len = \count($xa);
-        if ($len < \count($ya)) {
-            $len = \count($ya);
+        $len = is_countable($xa) ? \count($xa) : 0;
+        if ($len < (is_countable($ya) ? \count($ya) : 0)) {
+            $len = is_countable($ya) ? \count($ya) : 0;
         }
         if (1 < $len) {
             for ($idx = 0; $idx < $len; ++$idx) {

--- a/core/src/Util/EducationLevelSet.php
+++ b/core/src/Util/EducationLevelSet.php
@@ -108,10 +108,7 @@ class EducationLevelSet
                 return ['OT'];
             }
 
-            return array_map(static function (/* int */ $x): string {
-                /** @psalm-suppress RedundantCastGivenDocblockType */
-                return self::normalizeGrade((string) $x);
-            }, range($lo, $hi));
+            return array_map(static fn ($x): string => self::normalizeGrade((string) $x), range($lo, $hi));
         }
 
         return ['OT'];


### PR DESCRIPTION
- chore: make commands lazy
- chore: add imports for all class names
- chore: migrate DTOs to using attributes
- chore: migrate forms and voters to using attributes
- chore: migrate controllers to using attributes
- chore: migrate commands to using PHP 8 attributes
- chore: migrate entities to use attributes over annotations
- chore: use random_int over mt_rand
- chore: catch multiple exceptions at once
- chore: ensure nullable arrays are countable before using count()
- chore: use array_key_last() instead of getting the key after end()
- chore: throw errors when using json_decode()
- chore: use null coalescing
- chore: use arrow functions where applicable
- chore: is_countable not required in some cases
- chore: remove unused exception variable when not needed
- chore: use $obj::class over get_class($obj)
- chore: mark class constants as final
- chore: use str_start_with() method over alternatives
- chore: ensure nullable properties are defaulted to null
- chore: use never instead of void when method can never succeed
- chore: add _ separator for large numbers
- chore: use class constant instead of class name
- chore: change switch to match

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opensalt/opensalt/1831)
<!-- Reviewable:end -->
